### PR TITLE
feat: add interaction validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI / 검증
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  verify:
+    name: 검증 / Verify
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 체크아웃 / Checkout
+        uses: actions/checkout@v4
+
+      - name: Node 설정 / Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: 의존성 설치 / Install dependencies
+        run: npm ci
+
+      - name: 컴포넌트 검증 / Component validation
+        run: npm run test
+
+      - name: 타입 확인 / Typecheck
+        run: npm run typecheck
+
+      - name: 문서 앱 빌드 / Build docs app
+        run: npm --workspace @workspace/docs run build

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ Validates catalog component folders, required documents, required exports, token
 npm run test
 ```
 
-컴포넌트 시스템 검증, UI 빌드, 접근성 스모크 테스트, package export 검증을 한 번에 실행합니다.
-Runs component system validation, UI build, accessibility smoke checks, and package export verification together.
+컴포넌트 시스템 검증, UI 빌드, 접근성 스모크 테스트, 상호작용 접근성 테스트, package export 검증을 한 번에 실행합니다.
+Runs component system validation, UI build, accessibility smoke checks, interaction accessibility checks, and package export verification together.
 
 ## 컴포넌트 사용 / Component Usage
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,6 +18,7 @@ npm --workspace @workspace/docs run build
 - `packages/ui/src/components.tsx` 같은 중앙 구현 파일은 만들지 않습니다. / Do not create central implementation files such as `packages/ui/src/components.tsx`.
 - UI CSS에는 raw color 값을 직접 쓰지 않습니다. / UI CSS must not contain raw color values.
 - `test:a11y`는 핵심 accessible markup을 server render 기준으로 확인해야 합니다. / `test:a11y` must verify core accessible markup through server rendering.
+- `test:interaction`은 keyboard, focus return, highlighted option 같은 상호작용 접근성 흐름을 확인해야 합니다. / `test:interaction` must verify interaction accessibility flows such as keyboard, focus return, and highlighted options.
 - `test:exports`는 root export와 per-component export가 실제 `dist` 파일과 맞는지 확인해야 합니다. / `test:exports` must verify that root and per-component exports match real `dist` files.
 - React는 dependency가 아니라 peer dependency로 유지합니다. / React must remain a peer dependency, not a bundled dependency.
 

--- a/docs/review-and-issue-board.md
+++ b/docs/review-and-issue-board.md
@@ -22,6 +22,9 @@ This document is a lightweight backlog for items that should become GitHub Issue
 | [#5](https://github.com/BlingLab/frontend-lab/issues/5) | P1 | 패키지 릴리즈 정책 확정 / Define package release policy | release | package scope, registry, versioning, changelog 방식을 결정합니다. / Defines package scope, registry, versioning, and changelog flow. |
 | [#6](https://github.com/BlingLab/frontend-lab/issues/6) | P1 | DataGrid 고급 상호작용 설계 / Design advanced DataGrid interactions | component | column resize, row keyboard navigation, virtual scroll 여부를 결정합니다. / Decides column resize, row keyboard navigation, and virtual scroll scope. |
 | [#7](https://github.com/BlingLab/frontend-lab/issues/7) | Done | React 컴포넌트 시스템 하드닝 완료 기록 / Track completed hardening work | tracking | 완료된 component hardening 작업을 closed issue로 기록했습니다. / Completed component hardening work is recorded as a closed issue. |
+| [#8](https://github.com/BlingLab/frontend-lab/issues/8) | P1 | Button ref 전달 구조 개선 / Improve Button ref forwarding | component | overlay focus return이 explicit trigger ref 기반으로 동작합니다. / Overlay focus return works through explicit trigger refs. |
+| [#9](https://github.com/BlingLab/frontend-lab/issues/9) | P1 | Listbox highlight hook 공통화 / Extract shared listbox highlight hook | component | Combobox와 CommandPalette가 shared highlight hook을 사용합니다. / Combobox and CommandPalette use a shared highlight hook. |
+| [#10](https://github.com/BlingLab/frontend-lab/issues/10) | P1 | Overlay dismiss와 focus hook 공통화 / Extract overlay dismiss and focus hooks | component | Escape, outside pointer, focus return 로직이 shared hook으로 정리됩니다. / Escape, outside pointer, and focus return logic are consolidated into shared hooks. |
 
 ## PR 후보 / Pull Request Candidates
 
@@ -54,6 +57,12 @@ This document is a lightweight backlog for items that should become GitHub Issue
 - 범위 / Scope: keyboard row navigation, resize handle API, optional virtualized body decision.
 - 리뷰 포인트 / Review points: table semantics 유지, prop API 폭발 방지, responsive overflow.
 - 연결 이슈 / Linked issue: [#6](https://github.com/BlingLab/frontend-lab/issues/6)
+
+### 6. 상호작용 리팩토링 / Interaction Refactor
+
+- 범위 / Scope: Button ref forwarding, listbox highlight hook, overlay dismiss/focus hooks.
+- 리뷰 포인트 / Review points: focus return regression, keyboard behavior, hook API scope.
+- 연결 이슈 / Linked issues: [#8](https://github.com/BlingLab/frontend-lab/issues/8), [#9](https://github.com/BlingLab/frontend-lab/issues/9), [#10](https://github.com/BlingLab/frontend-lab/issues/10)
 
 ## 운영 방식 / Operating Flow
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,11 @@
         "vite": "^7.0.0"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0"
+        "@types/react-dom": "^19.0.0",
+        "jsdom": "^29.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -37,6 +40,57 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -256,6 +310,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -299,6 +363,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -717,6 +934,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -767,6 +1002,77 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
       "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -867,6 +1173,42 @@
       "resolved": "packages/ui",
       "link": true
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.23",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
@@ -877,6 +1219,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -938,12 +1290,40 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -962,11 +1342,50 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -1070,11 +1489,82 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1109,6 +1599,24 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1138,6 +1646,19 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1185,6 +1706,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -1206,10 +1753,28 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1244,6 +1809,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -1268,6 +1846,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -1282,6 +1867,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tsx": {
@@ -1314,6 +1945,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1419,6 +2060,71 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "build": "npm --workspace @workspace/ui run build",
     "dev": "npm --workspace @workspace/docs run dev",
     "docs:dev": "npm --workspace @workspace/docs run dev",
-    "test": "npm run components:validate && npm run build && tsx scripts/accessibility-smoke.mjs && tsx scripts/verify-package-exports.mjs",
+    "test": "npm run components:validate && npm run build && tsx scripts/accessibility-smoke.mjs && tsx scripts/interaction-a11y.mjs && tsx scripts/verify-package-exports.mjs",
     "test:a11y": "npm run build && tsx scripts/accessibility-smoke.mjs",
+    "test:interaction": "npm run build && tsx scripts/interaction-a11y.mjs",
     "test:exports": "npm run build && tsx scripts/verify-package-exports.mjs",
     "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck"
   },
@@ -28,8 +29,11 @@
     "vite": "^7.0.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "@types/react-dom": "^19.0.0",
+    "jsdom": "^29.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -144,5 +144,6 @@ npm --workspace @workspace/ui run typecheck
 npm run components:scaffold
 npm run components:validate
 npm run test:a11y
+npm run test:interaction
 npm run test:exports
 ```

--- a/packages/ui/src/components/actions/button/button.tsx
+++ b/packages/ui/src/components/actions/button/button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
 import type { ActionTone, Justify, Size, Variant } from "../../../shared/types";
 import { classNames, dataFlag } from "../../../shared/utils";
 
@@ -16,7 +16,7 @@ export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement
   iconEnd?: ReactNode;
 }
 
-export function Button({
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
   children,
   label,
   variant = "solid",
@@ -32,7 +32,7 @@ export function Button({
   iconEnd,
   className,
   ...props
-}: ButtonProps) {
+}, ref) {
   const isDisabled = disabled || loading;
 
   return (
@@ -48,6 +48,7 @@ export function Button({
       data-variant={variant}
       disabled={isDisabled}
       type={type}
+      ref={ref}
       aria-busy={loading || undefined}
       aria-pressed={selected || undefined}
       {...props}
@@ -58,4 +59,4 @@ export function Button({
       {iconEnd ? <span className="ds-Icon" aria-hidden="true">{iconEnd}</span> : null}
     </button>
   );
-}
+});

--- a/packages/ui/src/components/actions/icon-button/icon-button.tsx
+++ b/packages/ui/src/components/actions/icon-button/icon-button.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { forwardRef, type ReactNode } from "react";
 import { Button, type ButtonProps } from "../button";
 import { Icon } from "../icon";
 import { classNames } from "../../../shared/utils";
@@ -9,7 +9,7 @@ export interface IconButtonProps extends Omit<ButtonProps, "children" | "label">
   shape?: "square" | "circle";
 }
 
-export function IconButton({
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton({
   label,
   icon = <Icon name="plus" />,
   shape = "square",
@@ -17,7 +17,7 @@ export function IconButton({
   tone = "neutral",
   className,
   ...props
-}: IconButtonProps) {
+}, ref) {
   return (
     <Button
       aria-label={label}
@@ -25,9 +25,10 @@ export function IconButton({
       data-shape={shape}
       variant={variant}
       tone={tone}
+      ref={ref}
       {...props}
     >
       <span className="ds-Icon" aria-hidden="true">{icon}</span>
     </Button>
   );
-}
+});

--- a/packages/ui/src/components/forms/combobox/combobox.tsx
+++ b/packages/ui/src/components/forms/combobox/combobox.tsx
@@ -3,6 +3,7 @@ import { Field, type FieldProps } from "../field";
 import { Icon } from "../../actions/icon";
 import type { FieldWidth, Size } from "../../../shared/types";
 import { useControllableState } from "../../../shared/use-controllable-state";
+import { useListboxHighlight } from "../../../shared/use-listbox-highlight";
 import { classNames } from "../../../shared/utils";
 
 export interface ComboboxOption {
@@ -52,7 +53,6 @@ export function Combobox({
   const listboxId = `${controlId}-listbox`;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [selectedValue, setSelectedValue] = useControllableState({
     value,
     defaultValue,
@@ -68,30 +68,27 @@ export function Combobox({
       return haystack.includes(normalizedQuery);
     });
   }, [options, query]);
-  const highlightedOption = highlightedIndex >= 0 ? filteredOptions[highlightedIndex] : undefined;
-  const highlightedOptionId = highlightedOption ? `${listboxId}-${highlightedIndex}` : undefined;
+  const {
+    highlightedIndex,
+    highlightedItem: highlightedOption,
+    highlightedItemId: highlightedOptionId,
+    setHighlightedIndex,
+    resetHighlight,
+    highlightFirst,
+    moveHighlight,
+    getItemId
+  } = useListboxHighlight({ items: filteredOptions, idBase: listboxId });
 
   const selectOption = (option: ComboboxOption) => {
     if (option.disabled) return;
     setSelectedValue(option.value);
     setQuery("");
     setOpen(false);
-    setHighlightedIndex(-1);
-  };
-  const moveHighlight = (offset: number) => {
-    if (filteredOptions.length === 0) return;
-    let nextIndex = highlightedIndex;
-    for (let attempt = 0; attempt < filteredOptions.length; attempt += 1) {
-      nextIndex = (nextIndex + offset + filteredOptions.length) % filteredOptions.length;
-      if (!filteredOptions[nextIndex]?.disabled) {
-        setHighlightedIndex(nextIndex);
-        return;
-      }
-    }
+    resetHighlight();
   };
   const openListbox = () => {
     setOpen(true);
-    setHighlightedIndex((currentIndex) => currentIndex >= 0 ? currentIndex : filteredOptions.findIndex((option) => !option.disabled));
+    if (highlightedIndex < 0) highlightFirst();
   };
   const onInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "ArrowDown") {
@@ -111,7 +108,7 @@ export function Combobox({
     if (event.key === "Escape") {
       event.preventDefault();
       setOpen(false);
-      setHighlightedIndex(-1);
+      resetHighlight();
     }
   };
 
@@ -133,7 +130,7 @@ export function Combobox({
           aria-required={required || undefined}
           onBlur={() => window.setTimeout(() => {
             setOpen(false);
-            setHighlightedIndex(-1);
+            resetHighlight();
           }, 120)}
           onChange={(event) => {
             setQuery(event.currentTarget.value);
@@ -153,7 +150,7 @@ export function Combobox({
               data-selected={option.value === selectedValue ? "true" : undefined}
               data-highlighted={index === highlightedIndex ? "true" : undefined}
               disabled={option.disabled}
-              id={`${listboxId}-${index}`}
+              id={getItemId(index)}
               key={option.value}
               role="option"
               type="button"

--- a/packages/ui/src/components/overlays/command-palette/command-palette.tsx
+++ b/packages/ui/src/components/overlays/command-palette/command-palette.tsx
@@ -3,6 +3,8 @@ import { Button } from "../../actions/button";
 import { Icon } from "../../actions/icon";
 import { useControllableState } from "../../../shared/use-controllable-state";
 import { classNames } from "../../../shared/utils";
+import { useFocusReturn } from "../../../shared/use-focus-return";
+import { useListboxHighlight } from "../../../shared/use-listbox-highlight";
 
 export interface CommandPaletteCommand {
   label: ReactNode;
@@ -39,44 +41,41 @@ export function CommandPalette({
   ...props
 }: CommandPaletteProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const lastActiveRef = useRef<HTMLElement | null>(null);
+  const { triggerRef, rememberFocus, restoreFocus } = useFocusReturn<HTMLButtonElement>();
   const titleId = useId();
   const listId = useId();
   const [query, setQuery] = useState("");
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [currentOpen, setOpen] = useControllableState({ value: open, defaultValue: defaultOpen, onChange: onOpenChange });
   const filteredCommands = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     if (!normalizedQuery) return commands;
     return commands.filter((command) => [command.value, command.label?.toString(), command.description?.toString(), ...(command.keywords ?? [])].join(" ").toLowerCase().includes(normalizedQuery));
   }, [commands, query]);
-  const activeCommand = highlightedIndex >= 0 ? filteredCommands[highlightedIndex] : undefined;
-  const activeCommandId = activeCommand ? `${listId}-${highlightedIndex}` : undefined;
+  const {
+    highlightedIndex,
+    highlightedItem: activeCommand,
+    highlightedItemId: activeCommandId,
+    setHighlightedIndex,
+    moveHighlight,
+    getItemId
+  } = useListboxHighlight({ items: filteredCommands, idBase: listId });
 
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
     if (currentOpen && !dialog.open) {
-      lastActiveRef.current ??= document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      rememberFocus();
       dialog.showModal();
     }
     if (!currentOpen && dialog.open) dialog.close();
-  }, [currentOpen]);
+  }, [currentOpen, rememberFocus]);
 
   useEffect(() => {
-    const firstEnabledIndex = filteredCommands.findIndex((command) => !command.disabled);
-    setHighlightedIndex(firstEnabledIndex);
-  }, [filteredCommands]);
-
-  useEffect(() => {
-    if (currentOpen || !lastActiveRef.current) return;
-    const lastActive = lastActiveRef.current;
-    lastActiveRef.current = null;
-    window.setTimeout(() => lastActive.focus(), 0);
-  }, [currentOpen]);
+    if (!currentOpen) restoreFocus();
+  }, [currentOpen, restoreFocus]);
 
   const openPalette = () => {
-    lastActiveRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    rememberFocus();
     setOpen(true);
   };
   const closePalette = () => {
@@ -87,17 +86,6 @@ export function CommandPalette({
     if (command.disabled) return;
     onCommandSelect?.(command);
     closePalette();
-  };
-  const moveHighlight = (offset: number) => {
-    if (filteredCommands.length === 0) return;
-    let nextIndex = highlightedIndex;
-    for (let attempt = 0; attempt < filteredCommands.length; attempt += 1) {
-      nextIndex = (nextIndex + offset + filteredCommands.length) % filteredCommands.length;
-      if (!filteredCommands[nextIndex]?.disabled) {
-        setHighlightedIndex(nextIndex);
-        return;
-      }
-    }
   };
   const onPaletteKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "ArrowDown") {
@@ -120,7 +108,7 @@ export function CommandPalette({
 
   return (
     <div className={classNames("ds-CommandPaletteRoot", className)} {...props}>
-      <Button variant="outline" tone="neutral" aria-haspopup="dialog" aria-expanded={currentOpen} onClick={openPalette}>{triggerLabel}</Button>
+      <Button ref={triggerRef} variant="outline" tone="neutral" aria-haspopup="dialog" aria-expanded={currentOpen} onClick={openPalette}>{triggerLabel}</Button>
       <dialog className="ds-CommandPalette" data-state={currentOpen ? "open" : "closed"} ref={dialogRef} aria-labelledby={titleId} onCancel={closePalette} onClose={() => setOpen(false)}>
         <div className="ds-CommandPalette-header">
           <h3 id={titleId}>{title}</h3>
@@ -148,7 +136,7 @@ export function CommandPalette({
               className="ds-CommandPalette-item"
               data-highlighted={index === highlightedIndex ? "true" : undefined}
               disabled={command.disabled}
-              id={`${listId}-${index}`}
+              id={getItemId(index)}
               key={command.value}
               role="option"
               type="button"

--- a/packages/ui/src/components/overlays/dialog/dialog.tsx
+++ b/packages/ui/src/components/overlays/dialog/dialog.tsx
@@ -4,6 +4,7 @@ import { Icon } from "../../actions/icon";
 import { IconButton } from "../../actions/icon-button";
 import { classNames } from "../../../shared/utils";
 import { useControllableState } from "../../../shared/use-controllable-state";
+import { useFocusReturn } from "../../../shared/use-focus-return";
 
 export interface DialogProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
   triggerLabel?: ReactNode;
@@ -44,7 +45,7 @@ export function Dialog({
   ...props
 }: DialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const lastActiveRef = useRef<HTMLElement | null>(null);
+  const { triggerRef, rememberFocus, restoreFocus } = useFocusReturn<HTMLButtonElement>();
   const titleId = useId();
   const descriptionId = useId();
   const [currentOpen, setOpen] = useControllableState({
@@ -54,7 +55,7 @@ export function Dialog({
   });
   const close = () => setOpen(false);
   const openDialog = () => {
-    lastActiveRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    rememberFocus();
     setOpen(true);
   };
 
@@ -64,7 +65,7 @@ export function Dialog({
     if (!dialog) return;
 
     if (currentOpen && !dialog.open) {
-      lastActiveRef.current ??= document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      rememberFocus();
       if (modal) dialog.showModal();
       else dialog.show();
       initialFocus?.current?.focus();
@@ -76,15 +77,12 @@ export function Dialog({
   }, [currentOpen, initialFocus, modal]);
 
   useEffect(() => {
-    if (currentOpen || !lastActiveRef.current) return;
-    const lastActive = lastActiveRef.current;
-    lastActiveRef.current = null;
-    window.setTimeout(() => lastActive.focus(), 0);
-  }, [currentOpen]);
+    if (!currentOpen) restoreFocus();
+  }, [currentOpen, restoreFocus]);
 
   return (
     <div className={classNames("ds-DialogRoot", className)} data-state={currentOpen ? "open" : "closed"} {...props}>
-      <Button aria-haspopup="dialog" aria-expanded={currentOpen} onClick={openDialog}>{triggerLabel}</Button>
+      <Button ref={triggerRef} aria-haspopup="dialog" aria-expanded={currentOpen} onClick={openDialog}>{triggerLabel}</Button>
       <dialog
         className="ds-Dialog"
         data-size={size}

--- a/packages/ui/src/components/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu/dropdown-menu.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useId, useRef, type HTMLAttributes, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useRef, type HTMLAttributes, type KeyboardEvent, type ReactNode } from "react";
 import { Button } from "../../actions/button";
 import { classNames } from "../../../shared/utils";
 import { useControllableState } from "../../../shared/use-controllable-state";
+import { useFocusReturn } from "../../../shared/use-focus-return";
+import { useOverlayDismiss } from "../../../shared/use-overlay-dismiss";
 
 export interface DropdownMenuItem {
   label: ReactNode;
@@ -27,11 +29,11 @@ export function DropdownMenu({ triggerLabel = "메뉴 / Menu", items = [], open,
   const rootRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuId = useId();
-  const focusTrigger = () => rootRef.current?.querySelector<HTMLButtonElement>(".ds-Button")?.focus();
-  const closeMenu = (restoreFocus = true) => {
+  const { triggerRef, restoreFocus } = useFocusReturn<HTMLButtonElement>();
+  const closeMenu = useCallback((returnFocus = true) => {
     setOpen(false);
-    if (restoreFocus) focusTrigger();
-  };
+    if (returnFocus) restoreFocus();
+  }, [restoreFocus, setOpen]);
   const getEnabledItems = () => Array.from(menuRef.current?.querySelectorAll<HTMLButtonElement>(".ds-DropdownMenu-item:not(:disabled)") ?? []);
   const focusMenuItem = (offset: number, mode: "relative" | "absolute" = "relative") => {
     const enabledItems = getEnabledItems();
@@ -41,24 +43,18 @@ export function DropdownMenu({ triggerLabel = "메뉴 / Menu", items = [], open,
     enabledItems[Math.min(Math.max(nextIndex, 0), enabledItems.length - 1)]?.focus();
   };
 
+  useOverlayDismiss({
+    open: currentOpen,
+    rootRef,
+    onEscape: closeMenu,
+    onPointerDownOutside: () => closeMenu(false)
+  });
+
   useEffect(() => {
     if (!currentOpen) return undefined;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) closeMenu(false);
-    };
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeMenu();
-      }
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown);
     const animationFrame = window.requestAnimationFrame(() => focusMenuItem(0, "absolute"));
     return () => {
       window.cancelAnimationFrame(animationFrame);
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown);
     };
   }, [currentOpen]);
 
@@ -83,7 +79,7 @@ export function DropdownMenu({ triggerLabel = "메뉴 / Menu", items = [], open,
 
   return (
     <div className={classNames("ds-DropdownMenu", className)} data-state={currentOpen ? "open" : "closed"} ref={rootRef} {...props}>
-      <Button variant="outline" tone="neutral" aria-haspopup="menu" aria-expanded={currentOpen} aria-controls={menuId} onClick={() => setOpen((previousOpen) => !previousOpen)}>
+      <Button ref={triggerRef} variant="outline" tone="neutral" aria-haspopup="menu" aria-expanded={currentOpen} aria-controls={menuId} onClick={() => setOpen((previousOpen) => !previousOpen)}>
         {triggerLabel}
       </Button>
       <div className="ds-DropdownMenu-content" id={menuId} role="menu" data-placement={placement} data-state={currentOpen ? "open" : "closed"} hidden={!currentOpen} ref={menuRef} onKeyDown={onMenuKeyDown}>

--- a/packages/ui/src/components/overlays/popover/popover.tsx
+++ b/packages/ui/src/components/overlays/popover/popover.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useId, useRef, type HTMLAttributes, type ReactNode } from "react";
+import { useCallback, useId, useRef, type HTMLAttributes, type ReactNode } from "react";
 import { Button } from "../../actions/button";
 import { classNames } from "../../../shared/utils";
 import { useControllableState } from "../../../shared/use-controllable-state";
+import { useFocusReturn } from "../../../shared/use-focus-return";
+import { useOverlayDismiss } from "../../../shared/use-overlay-dismiss";
 
 export interface PopoverProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
   triggerLabel?: ReactNode;
@@ -20,34 +22,22 @@ export function Popover({ triggerLabel = "열기 / Open", title, children, open,
   });
   const rootRef = useRef<HTMLDivElement>(null);
   const panelId = useId();
-  const focusTrigger = () => rootRef.current?.querySelector<HTMLButtonElement>(".ds-Button")?.focus();
-  const closePopover = (restoreFocus = true) => {
+  const { triggerRef, restoreFocus } = useFocusReturn<HTMLButtonElement>();
+  const closePopover = useCallback((returnFocus = true) => {
     setOpen(false);
-    if (restoreFocus) focusTrigger();
-  };
+    if (returnFocus) restoreFocus();
+  }, [restoreFocus, setOpen]);
 
-  useEffect(() => {
-    if (!currentOpen) return undefined;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) closePopover(false);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closePopover();
-      }
-    };
-    document.addEventListener("pointerdown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [currentOpen]);
+  useOverlayDismiss({
+    open: currentOpen,
+    rootRef,
+    onEscape: closePopover,
+    onPointerDownOutside: () => closePopover(false)
+  });
 
   return (
     <div className={classNames("ds-Popover", className)} data-state={currentOpen ? "open" : "closed"} ref={rootRef} {...props}>
-      <Button variant="outline" tone="neutral" aria-expanded={currentOpen} aria-controls={panelId} onClick={() => setOpen((previousOpen) => !previousOpen)}>
+      <Button ref={triggerRef} variant="outline" tone="neutral" aria-expanded={currentOpen} aria-controls={panelId} onClick={() => setOpen((previousOpen) => !previousOpen)}>
         {triggerLabel}
       </Button>
       <div className="ds-Popover-panel" id={panelId} data-placement={placement} data-state={currentOpen ? "open" : "closed"} hidden={!currentOpen}>

--- a/packages/ui/src/shared/use-focus-return.ts
+++ b/packages/ui/src/shared/use-focus-return.ts
@@ -1,0 +1,22 @@
+import { useCallback, useRef, type RefObject } from "react";
+
+export function useFocusReturn<T extends HTMLElement = HTMLElement>() {
+  const triggerRef = useRef<T | null>(null);
+  const fallbackRef = useRef<HTMLElement | null>(null);
+
+  const rememberFocus = useCallback(() => {
+    fallbackRef.current = triggerRef.current ?? (document.activeElement instanceof HTMLElement ? document.activeElement : null);
+  }, []);
+
+  const restoreFocus = useCallback(() => {
+    const target = triggerRef.current ?? fallbackRef.current;
+    fallbackRef.current = null;
+    window.setTimeout(() => target?.focus(), 0);
+  }, []);
+
+  return { triggerRef, rememberFocus, restoreFocus } as {
+    triggerRef: RefObject<T | null>;
+    rememberFocus: () => void;
+    restoreFocus: () => void;
+  };
+}

--- a/packages/ui/src/shared/use-listbox-highlight.ts
+++ b/packages/ui/src/shared/use-listbox-highlight.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface ListboxHighlightItem {
+  disabled?: boolean;
+}
+
+export interface UseListboxHighlightOptions<Item extends ListboxHighlightItem> {
+  items: Item[];
+  idBase: string;
+  resetOnItemsChange?: boolean;
+}
+
+export function useListboxHighlight<Item extends ListboxHighlightItem>({
+  items,
+  idBase,
+  resetOnItemsChange = true
+}: UseListboxHighlightOptions<Item>) {
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const firstEnabledIndex = useMemo(() => items.findIndex((item) => !item.disabled), [items]);
+  const highlightedItem = highlightedIndex >= 0 ? items[highlightedIndex] : undefined;
+  const highlightedItemId = highlightedItem ? `${idBase}-${highlightedIndex}` : undefined;
+
+  useEffect(() => {
+    if (resetOnItemsChange) setHighlightedIndex(firstEnabledIndex);
+  }, [firstEnabledIndex, resetOnItemsChange]);
+
+  const resetHighlight = useCallback(() => setHighlightedIndex(-1), []);
+  const highlightFirst = useCallback(() => setHighlightedIndex(firstEnabledIndex), [firstEnabledIndex]);
+  const getItemId = useCallback((index: number) => `${idBase}-${index}`, [idBase]);
+
+  const moveHighlight = useCallback((offset: number) => {
+    if (items.length === 0) return;
+
+    let nextIndex = highlightedIndex;
+    for (let attempt = 0; attempt < items.length; attempt += 1) {
+      nextIndex = (nextIndex + offset + items.length) % items.length;
+      if (!items[nextIndex]?.disabled) {
+        setHighlightedIndex(nextIndex);
+        return;
+      }
+    }
+  }, [highlightedIndex, items]);
+
+  return {
+    highlightedIndex,
+    highlightedItem,
+    highlightedItemId,
+    setHighlightedIndex,
+    resetHighlight,
+    highlightFirst,
+    moveHighlight,
+    getItemId
+  };
+}

--- a/packages/ui/src/shared/use-overlay-dismiss.ts
+++ b/packages/ui/src/shared/use-overlay-dismiss.ts
@@ -1,0 +1,39 @@
+import { useEffect, type RefObject } from "react";
+
+export interface UseOverlayDismissOptions {
+  open: boolean;
+  rootRef: RefObject<HTMLElement | null>;
+  onEscape?: () => void;
+  onPointerDownOutside?: () => void;
+}
+
+export function useOverlayDismiss({
+  open,
+  rootRef,
+  onEscape,
+  onPointerDownOutside
+}: UseOverlayDismissOptions) {
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        onPointerDownOutside?.();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onEscape?.();
+      }
+    };
+
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onEscape, onPointerDownOutside, open, rootRef]);
+}

--- a/scripts/interaction-a11y.mjs
+++ b/scripts/interaction-a11y.mjs
@@ -1,0 +1,177 @@
+import { JSDOM } from "jsdom";
+import React from "react";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/"
+});
+
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
+globalThis.HTMLDialogElement = dom.window.HTMLDialogElement;
+globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.Node = dom.window.Node;
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: dom.window.navigator
+});
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+
+if (!globalThis.HTMLDialogElement.prototype.showModal) {
+  globalThis.HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+}
+
+if (!globalThis.HTMLDialogElement.prototype.show) {
+  globalThis.HTMLDialogElement.prototype.show = function show() {
+    this.open = true;
+  };
+}
+
+if (!globalThis.HTMLDialogElement.prototype.close) {
+  globalThis.HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+    this.dispatchEvent(new dom.window.Event("close"));
+  };
+}
+
+const { cleanup, fireEvent, render, screen, waitFor } = await import("@testing-library/react");
+const userEvent = (await import("@testing-library/user-event")).default;
+const {
+  Combobox,
+  CommandPalette,
+  Dialog,
+  DropdownMenu,
+  Popover
+} = await import("../packages/ui/dist/index.js");
+
+const failures = [];
+
+async function check(name, fn) {
+  try {
+    cleanup();
+    await fn();
+  } catch (error) {
+    failures.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+    cleanup();
+  }
+}
+
+await check("Combobox keyboard selection", async () => {
+  render(React.createElement(Combobox, {
+    label: "담당자 / Owner",
+    options: [
+      { label: "디자인 / Design", value: "design" },
+      { label: "프론트엔드 / Frontend", value: "frontend" }
+    ]
+  }));
+
+  const input = screen.getByRole("combobox");
+  fireEvent.focus(input);
+  await waitFor(() => {
+    if (!input.getAttribute("aria-activedescendant")) {
+      throw new Error("Expected combobox to highlight the first option on focus.");
+    }
+  });
+  fireEvent.keyDown(input, { key: "ArrowDown" });
+  fireEvent.keyDown(input, { key: "Enter" });
+
+  await waitFor(() => {
+    if (input.value !== "프론트엔드 / Frontend") {
+      throw new Error(`Expected second option to be selected, received: ${input.value}`);
+    }
+  });
+});
+
+await check("CommandPalette keyboard selection", async () => {
+  let selected = "";
+  const user = userEvent.setup();
+  render(React.createElement(CommandPalette, {
+    commands: [
+      { label: "프로젝트 열기 / Open project", value: "open" },
+      { label: "새 컴포넌트 / New component", value: "new" }
+    ],
+    onCommandSelect: (command) => {
+      selected = command.value;
+    }
+  }));
+
+  await user.click(screen.getByRole("button", { name: "명령 열기 / Open commands" }));
+  const input = screen.getByRole("combobox");
+  fireEvent.keyDown(input, { key: "ArrowDown" });
+  fireEvent.keyDown(input, { key: "Enter" });
+
+  await waitFor(() => {
+    if (selected !== "new") throw new Error(`Expected command "new", received: ${selected}`);
+  });
+});
+
+await check("DropdownMenu keyboard focus return", async () => {
+  const user = userEvent.setup();
+  render(React.createElement(DropdownMenu, {
+    triggerLabel: "작업 / Actions",
+    items: [
+      { label: "편집 / Edit" },
+      { label: "삭제 / Delete" }
+    ]
+  }));
+
+  const trigger = screen.getByRole("button", { name: "작업 / Actions" });
+  await user.click(trigger);
+  await waitFor(() => {
+    if (document.activeElement?.textContent !== "편집 / Edit") {
+      throw new Error("Expected first menu item to receive focus.");
+    }
+  });
+  fireEvent.keyDown(document.activeElement, { key: "Escape" });
+
+  await waitFor(() => {
+    if (document.activeElement !== trigger) throw new Error("Expected focus to return to dropdown trigger.");
+  });
+});
+
+await check("Popover Escape focus return", async () => {
+  const user = userEvent.setup();
+  render(React.createElement(Popover, {
+    triggerLabel: "필터 / Filter",
+    title: "필터 옵션 / Filter options"
+  }));
+
+  const trigger = screen.getByRole("button", { name: "필터 / Filter" });
+  await user.click(trigger);
+  fireEvent.keyDown(document, { key: "Escape" });
+
+  await waitFor(() => {
+    if (document.activeElement !== trigger) throw new Error("Expected focus to return to popover trigger.");
+  });
+});
+
+await check("Dialog close focus return", async () => {
+  const user = userEvent.setup();
+  render(React.createElement(Dialog, {
+    triggerLabel: "열기 / Open",
+    title: "확인 / Confirm",
+    closeLabel: "닫기 / Close"
+  }));
+
+  const trigger = screen.getByRole("button", { name: "열기 / Open" });
+  await user.click(trigger);
+  await user.click(screen.getAllByRole("button", { name: "닫기 / Close" })[0]);
+
+  await waitFor(() => {
+    if (document.activeElement !== trigger) throw new Error("Expected focus to return to dialog trigger.");
+  });
+});
+
+if (failures.length > 0) {
+  console.error(failures.join("\n\n"));
+  process.exit(1);
+}
+
+console.log("상호작용 접근성 검증 완료. / Interaction accessibility checks passed.");

--- a/scripts/validate-component-system.mjs
+++ b/scripts/validate-component-system.mjs
@@ -157,8 +157,8 @@ for (const exportName of requiredExports) {
   const componentSource = await readFile(componentFile, "utf8").catch(() => "");
   const entrySource = await readFile(entryFile, "utf8").catch(() => "");
 
-  if (!componentSource.includes(`export function ${exportName}`)) {
-    failures.push(`${exportName} 구현은 자기 폴더의 ${slug}.tsx에 있어야 합니다. / ${exportName} implementation must live in its own ${slug}.tsx file.`);
+  if (!componentSource.includes(`export function ${exportName}`) && !componentSource.includes(`export const ${exportName}`)) {
+    failures.push(`${exportName} 구현은 자기 폴더의 ${slug}.tsx에서 named export여야 합니다. / ${exportName} implementation must be a named export in its own ${slug}.tsx file.`);
   }
   if (!entrySource.includes(`./${slug}`)) {
     failures.push(`${exportName} index.ts는 같은 폴더의 ${slug}.tsx를 export해야 합니다. / ${exportName} index.ts must export from ./${slug}.`);


### PR DESCRIPTION
# PR 요약 / PR Summary

## 변경 목적 / Purpose

- 컴포넌트 상호작용과 CI 검증 흐름을 PR 절차 안에서 재사용 가능하게 정리합니다. / Organizes component interaction behavior and CI validation so they can be reused through the PR workflow.

## 변경 흐름 / Change Flow

- [x] 기능 또는 구조 변경: Changes 탭에서 셀프 리뷰했습니다. / Feature or structure change: self-reviewed the Changes tab.
- [ ] 위험한 변경: 아래 위험 체크리스트를 작성했습니다. / Risky change: completed the risk checklist below.
- [ ] 작은 수정이면 PR 대신 `main` 바로 push 대상입니다. / Small changes should usually be pushed directly to `main` instead of using a PR.

## 변경 범위 / Scope

- [x] 컴포넌트 구현 / Component implementation
- [ ] 디자인 토큰 또는 테마 / Design tokens or themes
- [x] 문서 또는 docs app / Documentation or docs app
- [x] 테스트, 검증, 빌드 설정 / Tests, validation, or build configuration

## 리뷰 포인트 / Review Points

- [x] public API와 prop 이름이 기존 규칙과 맞습니다. / Public API and prop names follow existing conventions.
- [x] controlled/uncontrolled 상태와 `on*Change` callback이 일관됩니다. / Controlled/uncontrolled state and `on*Change` callbacks are consistent.
- [x] keyboard, focus-visible, disabled, invalid 상태가 동작합니다. / Keyboard, focus-visible, disabled, and invalid states work.
- [x] CSS는 `--ds-*` token을 사용하고 raw color를 쓰지 않습니다. / CSS uses `--ds-*` tokens and avoids raw colors.
- [x] 문서와 예시가 실제 구현과 맞습니다. / Documentation and examples match the implementation.

## 검증 / Verification

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm --workspace @workspace/docs run build`
- [x] `git diff --check`

## 셀프 리뷰 메모 / Self Review Notes

- Button과 IconButton은 `forwardRef`로 overlay trigger focus return을 명시적으로 지원합니다. / Button and IconButton now use `forwardRef` for explicit overlay trigger focus return.
- Combobox와 CommandPalette는 `useListboxHighlight`로 keyboard highlight 흐름을 공유합니다. / Combobox and CommandPalette share keyboard highlight behavior through `useListboxHighlight`.
- Popover와 DropdownMenu는 `useOverlayDismiss`, Dialog와 CommandPalette는 `useFocusReturn`로 dismiss/focus 흐름을 정리했습니다. / Popover and DropdownMenu use `useOverlayDismiss`, while Dialog and CommandPalette use `useFocusReturn` to consolidate dismiss/focus behavior.
- GitHub Actions CI가 push/PR에서 test, typecheck, docs build를 실행합니다. / GitHub Actions CI runs test, typecheck, and docs build on push and PR.

## 위험 체크리스트 / Risk Checklist

- 영향 항목: Button ref API, interaction test dependency, CI workflow. / Affected areas: Button ref API, interaction test dependencies, and CI workflow.
- migration: 기존 Button 사용 코드는 변경 없이 동작하며 ref 사용만 추가됩니다. / Migration: existing Button usage continues to work, with ref support added.
- rollback: 이 PR revert 시 shared hook 도입과 CI workflow 변경을 함께 되돌립니다. / Rollback: reverting this PR removes the shared hooks and CI workflow changes together.
- 접근성: Escape, keyboard selection, focus return 검증을 추가했습니다. / Accessibility: added checks for Escape, keyboard selection, and focus return.

## 후속 이슈 / Follow-Up Issues

Closes #1
Closes #2
Closes #8
Closes #9
Closes #10
