### PR TITLE
feat: add docs component coverage matrix

### DIFF
--- a/apps/docs/src/main.tsx
+++ b/apps/docs/src/main.tsx
@@ -262,6 +262,27 @@ const showcase: Record<string, { preview: ReactNode; code: string }> = {
   }
 };
 
+const docsRepositoryBaseUrl = "https://github.com/BlingLab/frontend-lab/tree/main";
+const priorityStateNames = ["default", "hover", "focus-visible", "disabled", "invalid", "selected", "open", "loading", "active", "empty"];
+
+function getComponentDocPaths(component: (typeof componentCatalog)[number]) {
+  const directory = `packages/ui/src/components/${component.category}/${component.slug}`;
+  return {
+    directory,
+    source: `${directory}/${component.slug}.tsx`,
+    readme: `${directory}/README.md`,
+    spec: `${directory}/spec.md`,
+    docsUrl: `${docsRepositoryBaseUrl}/${directory}`,
+    readmeUrl: `${docsRepositoryBaseUrl}/${directory}/README.md`,
+    specUrl: `${docsRepositoryBaseUrl}/${directory}/spec.md`
+  };
+}
+
+function getCoveredStates(component: (typeof componentCatalog)[number]) {
+  const prioritizedStates = priorityStateNames.filter((stateName) => component.states.includes(stateName));
+  return prioritizedStates.length > 0 ? prioritizedStates : component.states.slice(0, 4);
+}
+
 function App() {
   const [activeSection, setActiveSection] = useState(navItems[0].id);
   const [activeTheme, setActiveTheme] = useState("normal");
@@ -284,9 +305,21 @@ function App() {
     ].join(" ").toLowerCase().includes(normalizedQuery));
   }, [componentQuery]);
   const selectedComponent = componentCatalog.find((component) => component.name === selectedComponentName) ?? filteredComponents[0] ?? componentCatalog[0];
-  const selectedSourcePath = `packages/ui/src/components/${selectedComponent.category}/${selectedComponent.slug}/${selectedComponent.slug}.tsx`;
-  const selectedReadmePath = `packages/ui/src/components/${selectedComponent.category}/${selectedComponent.slug}/README.md`;
-  const selectedSpecPath = `packages/ui/src/components/${selectedComponent.category}/${selectedComponent.slug}/spec.md`;
+  const selectedDocPaths = getComponentDocPaths(selectedComponent);
+  const coverageRows = useMemo(() => componentCatalog.map((component) => {
+    const docPaths = getComponentDocPaths(component);
+    return {
+      component,
+      docPaths,
+      hasExample: Boolean(showcase[component.name]),
+      coveredStates: getCoveredStates(component)
+    };
+  }), []);
+  const coverageCounts = useMemo(() => ({
+    examples: coverageRows.filter((row) => row.hasExample).length,
+    docs: coverageRows.filter((row) => row.docPaths.readme && row.docPaths.spec).length,
+    themes: themeOptions.filter((theme) => theme.id === "normal" || theme.id === "dark").length
+  }), [coverageRows]);
 
   useEffect(() => {
     document.documentElement.dataset.dsTheme = activeTheme;
@@ -595,22 +628,81 @@ function App() {
                 <div>{selectedComponent.tokens.map((token) => <span key={token}>{token}</span>)}</div>
               </div>
               <div className="doc-paths">
-                <code>{selectedSourcePath}</code>
-                <code>{selectedReadmePath}</code>
-                <code>{selectedSpecPath}</code>
+                <code>{selectedDocPaths.source}</code>
+                <code>{selectedDocPaths.readme}</code>
+                <code>{selectedDocPaths.spec}</code>
               </div>
+              <Inline gap="sm">
+                <a className="doc-link" href={selectedDocPaths.readmeUrl} target="_blank" rel="noreferrer">README</a>
+                <a className="doc-link" href={selectedDocPaths.specUrl} target="_blank" rel="noreferrer">Spec</a>
+              </Inline>
             </article>
           </div>
+          <section className="coverage-panel" aria-labelledby="component-coverage-title">
+            <div className="coverage-header">
+              <div>
+                <h3 id="component-coverage-title">컴포넌트 커버리지 매트릭스 / Component Coverage Matrix</h3>
+                <p>catalog 기준으로 예시, 상태, NORMAL/DARK theme, README/spec 링크를 한 번에 확인합니다. / Review examples, states, NORMAL/DARK themes, and README/spec links from the catalog.</p>
+              </div>
+              <div className="coverage-summary" aria-label="커버리지 요약 / Coverage summary">
+                <Badge label={`${coverageCounts.examples}/${componentCatalog.length} examples`} tone="success" />
+                <Badge label={`${coverageCounts.docs}/${componentCatalog.length} docs`} tone="brand" />
+                <Badge label={`${coverageCounts.themes} themes`} tone="neutral" />
+              </div>
+            </div>
+            <div className="coverage-table-wrap">
+              <table className="coverage-table">
+                <caption>컴포넌트 예시와 문서 연결 상태 / Component example and documentation link status</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">컴포넌트 / Component</th>
+                    <th scope="col">예시 / Example</th>
+                    <th scope="col">상태 커버리지 / State Coverage</th>
+                    <th scope="col">테마 / Theme</th>
+                    <th scope="col">문서 / Docs</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {coverageRows.map(({ component, docPaths, hasExample, coveredStates }) => (
+                    <tr key={component.name}>
+                      <th scope="row">
+                        <a href={`#component-${component.slug}`}>{component.name}</a>
+                        <span>{component.category} · {component.priority}</span>
+                      </th>
+                      <td><Badge label={hasExample ? "렌더링됨 / Rendered" : "필요 / Needed"} tone={hasExample ? "success" : "warning"} /></td>
+                      <td>
+                        <div className="coverage-state-list">
+                          {coveredStates.map((state) => <span key={state}>{state}</span>)}
+                        </div>
+                      </td>
+                      <td>NORMAL / DARK</td>
+                      <td>
+                        <Inline gap="sm">
+                          <a href={docPaths.readmeUrl} target="_blank" rel="noreferrer">README</a>
+                          <a href={docPaths.specUrl} target="_blank" rel="noreferrer">Spec</a>
+                        </Inline>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
           <div className="component-list">
             {componentCatalog.map((component) => {
               const example = showcase[component.name];
               const summary = summaries.get(component.name);
+              const docPaths = getComponentDocPaths(component);
               return (
-                <article className="component-card" key={component.name}>
+                <article className="component-card" id={`component-${component.slug}`} key={component.name}>
                   <div className="component-info">
                     <h3>{component.name}</h3>
                     <p className="component-meta">{component.priority} · {component.category} · {component.status}</p>
                     <p className="component-copy">{summary?.summary} / {summary?.purpose}</p>
+                    <Inline gap="sm">
+                      <a className="doc-link" href={docPaths.readmeUrl} target="_blank" rel="noreferrer">README</a>
+                      <a className="doc-link" href={docPaths.specUrl} target="_blank" rel="noreferrer">Spec</a>
+                    </Inline>
                     <div className="code-block"><pre><code>{example?.code ?? `import { ${component.name} } from "@workspace/ui";`}</code></pre></div>
                   </div>
                   <div className="preview" aria-label={`${component.name} 미리보기 / ${component.name} preview`}>

--- a/apps/docs/src/smoke.tsx
+++ b/apps/docs/src/smoke.tsx
@@ -4,7 +4,13 @@ import "../styles.css";
 
 import { StrictMode, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
-import { Alert, Button, Combobox, CommandPalette, DataGrid, DatePicker, Dialog, DropdownMenu, FileUploader, NavigationRail, Popover, Stack, Stepper, Switch, Tabs, TextField } from "@workspace/ui";
+import { Alert, Button, Combobox, CommandPalette, DataGrid, DatePicker, Dialog, DropdownMenu, FileUploader, NavigationRail, Popover, Stack, Stepper, Switch, Tabs, TextField, componentCatalog } from "@workspace/ui";
+
+const docsRepositoryBaseUrl = "https://github.com/BlingLab/frontend-lab/tree/main";
+
+function getComponentReadmeUrl(component: (typeof componentCatalog)[number]) {
+  return `${docsRepositoryBaseUrl}/packages/ui/src/components/${component.category}/${component.slug}/README.md`;
+}
 
 function SmokeCard({ title, children }: { title: string; children: ReactNode }) {
   return (
@@ -21,6 +27,11 @@ function SmokeApp() {
       <header>
         <h1>컴포넌트 smoke 확인 / Component Smoke Check</h1>
         <p>이 화면은 실제 `@workspace/ui` React export만 사용합니다. / This page uses only real `@workspace/ui` React exports.</p>
+        <nav className="smoke-doc-links" aria-label="컴포넌트 문서 링크 / Component documentation links">
+          {componentCatalog.map((component) => (
+            <a href={getComponentReadmeUrl(component)} key={component.name} target="_blank" rel="noreferrer">{component.name}</a>
+          ))}
+        </nav>
       </header>
       <section className="smoke-grid" id="smoke-root">
         <SmokeCard title="Switch">

--- a/apps/docs/styles.css
+++ b/apps/docs/styles.css
@@ -794,6 +794,129 @@ pre {
   font-size: var(--ds-font-size-12);
 }
 
+.doc-link {
+  display: inline-flex;
+  min-height: var(--ds-size-control-sm);
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--ds-radius-6);
+  background: var(--surface);
+  color: var(--text);
+  padding: var(--ds-space-0) var(--ds-space-3);
+  font-size: var(--ds-font-size-12);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.doc-link:hover,
+.doc-link:focus-visible {
+  border-color: var(--ds-state-hover-border);
+  background: var(--ds-state-hover-bg);
+  outline: none;
+  box-shadow: var(--ds-focus-ring);
+}
+
+.coverage-panel {
+  display: grid;
+  gap: var(--ds-space-4);
+  margin-bottom: var(--ds-space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--ds-shadow-low);
+  padding: var(--ds-space-5);
+}
+
+.coverage-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--ds-space-4);
+}
+
+.coverage-header h3 {
+  margin-bottom: var(--ds-space-2);
+}
+
+.coverage-header p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.coverage-summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+}
+
+.coverage-table-wrap {
+  overflow-x: auto;
+}
+
+.coverage-table {
+  inline-size: 100%;
+  min-inline-size: 58rem;
+  border-collapse: collapse;
+  font-size: var(--ds-font-size-13);
+}
+
+.coverage-table caption {
+  color: var(--muted);
+  margin-block-end: var(--ds-space-2);
+  text-align: start;
+}
+
+.coverage-table th,
+.coverage-table td {
+  border-block-end: 1px solid var(--border);
+  padding: var(--ds-space-3);
+  text-align: start;
+  vertical-align: top;
+}
+
+.coverage-table thead th {
+  background: var(--surface-muted);
+  color: var(--text);
+  font-weight: 800;
+}
+
+.coverage-table tbody th {
+  display: grid;
+  gap: var(--ds-space-1);
+}
+
+.coverage-table tbody th a,
+.coverage-table td a {
+  color: var(--primary);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.coverage-table tbody th span {
+  color: var(--muted);
+  font-size: var(--ds-font-size-12);
+  font-weight: 700;
+}
+
+.coverage-state-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-space-2);
+}
+
+.coverage-state-list span {
+  display: inline-flex;
+  min-height: 1.5rem;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--ds-radius-pill);
+  background: var(--surface-muted);
+  padding: var(--ds-space-0) var(--ds-space-2);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: var(--ds-font-size-12);
+}
+
 .component-list {
   display: grid;
   gap: var(--ds-space-5);
@@ -896,6 +1019,35 @@ pre {
   padding: var(--ds-space-8);
 }
 
+.smoke-doc-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-space-2);
+  margin-top: var(--ds-space-4);
+}
+
+.smoke-doc-links a {
+  display: inline-flex;
+  min-height: var(--ds-size-control-sm);
+  align-items: center;
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-radius-pill);
+  background: var(--ds-color-bg-surface);
+  color: var(--ds-color-action-primary-bg);
+  padding: var(--ds-space-0) var(--ds-space-3);
+  font-size: var(--ds-font-size-12);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.smoke-doc-links a:hover,
+.smoke-doc-links a:focus-visible {
+  border-color: var(--ds-state-hover-border);
+  background: var(--ds-state-hover-bg);
+  outline: none;
+  box-shadow: var(--ds-focus-ring);
+}
+
 .smoke-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -927,9 +1079,18 @@ pre {
 
   .component-card,
   .docs-explorer,
+  .coverage-header,
   .theme-layout,
   .workflow-preview {
     grid-template-columns: 1fr;
+  }
+
+  .coverage-header {
+    display: grid;
+  }
+
+  .coverage-summary {
+    justify-content: flex-start;
   }
 
   .theme-compare {
@@ -966,6 +1127,7 @@ pre {
   .intro,
   .component-card,
   .docs-explorer,
+  .coverage-header,
   .theme-layout,
   .workflow-preview {
     grid-template-columns: 1fr;

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -4,6 +4,14 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: fileURLToPath(new URL("index.html", import.meta.url)),
+        smoke: fileURLToPath(new URL("component-smoke.html", import.meta.url))
+      }
+    }
+  },
   resolve: {
     alias: [
       {


### PR DESCRIPTION
# PR 요약 / PR Summary

## 변경 목적 / Purpose

- catalog 기준으로 docs app component example coverage와 README/spec 연결 상태를 한 화면에서 확인하게 합니다. / Adds a catalog-based docs app view for component example coverage and README/spec link status.

## 변경 흐름 / Change Flow

- [x] 기능 또는 구조 변경: Changes 탭에서 셀프 리뷰했습니다. / Feature or structure change: self-reviewed the Changes tab.
- [ ] 위험한 변경: 아래 위험 체크리스트를 작성했습니다. / Risky change: completed the risk checklist below.
- [ ] 작은 수정이면 PR 대신 `main` 바로 push 대상입니다. / Small changes should usually be pushed directly to `main` instead of using a PR.

## 변경 범위 / Scope

- [ ] 컴포넌트 구현 / Component implementation
- [ ] 디자인 토큰 또는 테마 / Design tokens or themes
- [x] 문서 또는 docs app / Documentation or docs app
- [x] 테스트, 검증, 빌드 설정 / Tests, validation, or build configuration

## 리뷰 포인트 / Review Points

- [x] public API와 prop 이름이 기존 규칙과 맞습니다. / Public API and prop names follow existing conventions.
- [x] controlled/uncontrolled 상태와 `on*Change` callback이 일관됩니다. / Controlled/uncontrolled state and `on*Change` callbacks are consistent.
- [x] keyboard, focus-visible, disabled, invalid 상태가 동작합니다. / Keyboard, focus-visible, disabled, and invalid states work.
- [x] CSS는 `--ds-*` token을 사용하고 raw color를 쓰지 않습니다. / CSS uses `--ds-*` tokens and avoids raw colors.
- [x] 문서와 예시가 실제 구현과 맞습니다. / Documentation and examples match the implementation.

## 검증 / Verification

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm --workspace @workspace/docs run build`
- [x] `git diff --check`

## 셀프 리뷰 메모 / Self Review Notes

- docs app에 35개 component catalog 기반 coverage matrix를 추가했습니다. / Added a 35-component catalog-based coverage matrix to the docs app.
- 각 component row는 rendered example, covered states, NORMAL/DARK theme, README/spec link를 보여줍니다. / Each component row shows rendered example, covered states, NORMAL/DARK theme, and README/spec links.
- component-smoke page가 componentCatalog 기반 README link index를 제공합니다. / The component-smoke page now provides a componentCatalog-based README link index.
- Vite build가 `index.html`과 `component-smoke.html`을 모두 산출합니다. / Vite build now outputs both `index.html` and `component-smoke.html`.

## 위험 체크리스트 / Risk Checklist

- [ ] public API, token, package export, dependency, CI required check 중 영향받는 항목을 적었습니다. / Listed affected public API, token, package export, dependency, or CI required check.
- [ ] migration 또는 rollback 방법을 적었습니다. / Documented migration or rollback path.
- [ ] 접근성, focus, keyboard regression 가능성을 확인했습니다. / Checked accessibility, focus, and keyboard regression risk.
- [ ] 관련 문서, README, component spec를 함께 업데이트했습니다. / Updated related docs, README, and component specs.

## 후속 이슈 / Follow-Up Issues

Closes #14
