### PR TITLE
[codex] Add Playwright visual regression checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,16 @@ jobs:
 
       - name: 문서 앱 빌드 / Build docs app
         run: npm --workspace @workspace/docs run build
+
+      - name: Playwright 브라우저 설치 / Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: 시각 회귀 검증 / Visual regression
+        run: npm run test:visual
+
+      - name: 시각 회귀 산출물 업로드 / Upload visual artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression
+          path: artifacts/visual-regression

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ lib-cov
 coverage
 *.lcov
 
+# Visual regression artifacts
+artifacts/
+
 # nyc test coverage
 .nyc_output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes are documented in this file.
 - DataGrid row keyboard navigation과 column resize API를 추가했습니다. / Added DataGrid row keyboard navigation and column resize APIs.
 - 시각 회귀, 릴리즈 정책, 브랜치 보호 기준 문서를 추가했습니다. / Added visual regression, release policy, and branch protection criteria docs.
 - UI package build 전에 stale `dist`를 정리하는 스크립트를 추가했습니다. / Added a script that cleans stale `dist` output before building the UI package.
+- Playwright 기반 docs app screenshot 검증을 추가했습니다. / Added Playwright-based docs app screenshot validation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ npm run test
 컴포넌트 시스템 검증, UI 빌드, 접근성 스모크 테스트, 상호작용 접근성 테스트, package export 검증을 한 번에 실행합니다.
 Runs component system validation, UI build, accessibility smoke checks, interaction accessibility checks, and package export verification together.
 
+```bash
+npm run test:visual
+```
+
+문서 앱 home, theme compare, DataGrid 예시를 NORMAL/DARK와 mobile/tablet/desktop viewport에서 screenshot으로 확인합니다.
+Checks docs app home, theme compare, and DataGrid examples with screenshots across NORMAL/DARK and mobile/tablet/desktop viewports.
+
 ## 컴포넌트 사용 / Component Usage
 
 전체 API는 `@workspace/ui`에서 import합니다.

--- a/apps/docs/styles.css
+++ b/apps/docs/styles.css
@@ -133,6 +133,7 @@ select {
 }
 
 .content {
+  width: 100%;
   min-width: 0;
   max-width: 82rem;
   padding: var(--ds-space-8) var(--ds-space-8) var(--ds-space-12);
@@ -851,6 +852,7 @@ pre {
 }
 
 .coverage-table-wrap {
+  min-width: 0;
   overflow-x: auto;
 }
 
@@ -929,6 +931,13 @@ pre {
   padding: var(--ds-space-5);
 }
 
+.component-card > *,
+.docs-explorer > *,
+.theme-layout > *,
+.workflow-preview > * {
+  min-width: 0;
+}
+
 .component-card h3 {
   margin-bottom: 6px;
 }
@@ -940,7 +949,10 @@ pre {
 
 .preview {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
   min-height: 11rem;
+  overflow-x: auto;
   place-items: center;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -950,6 +962,11 @@ pre {
   background-color: var(--surface);
   background-size: 20px 20px;
   padding: var(--ds-space-5);
+}
+
+.preview > * {
+  max-width: 100%;
+  min-width: 0;
 }
 
 .field input,
@@ -965,6 +982,7 @@ pre {
 
 .code-block {
   margin: 16px 0 0;
+  min-width: 0;
   border-radius: var(--radius);
   background: var(--ds-color-bg-inverse);
   color: var(--ds-color-gray-150);

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -11,6 +11,7 @@ npm run test
 npm run typecheck
 npm run build
 npm --workspace @workspace/docs run build
+npm run test:visual
 npm pack --workspace @workspace/ui --dry-run
 ```
 
@@ -21,6 +22,7 @@ npm pack --workspace @workspace/ui --dry-run
 - UI CSS에는 raw color 값을 직접 쓰지 않습니다. / UI CSS must not contain raw color values.
 - `test:a11y`는 핵심 accessible markup을 server render 기준으로 확인해야 합니다. / `test:a11y` must verify core accessible markup through server rendering.
 - `test:interaction`은 keyboard, focus return, highlighted option 같은 상호작용 접근성 흐름을 확인해야 합니다. / `test:interaction` must verify interaction accessibility flows such as keyboard, focus return, and highlighted options.
+- `test:visual`은 docs app home, theme compare, DataGrid screenshot과 horizontal overflow를 확인해야 합니다. / `test:visual` must verify docs app home, theme compare, DataGrid screenshots, and horizontal overflow.
 - `test:exports`는 root export와 per-component export가 실제 `dist` 파일과 맞는지 확인해야 합니다. / `test:exports` must verify that root and per-component exports match real `dist` files.
 - React는 dependency가 아니라 peer dependency로 유지합니다. / React must remain a peer dependency, not a bundled dependency.
 

--- a/docs/visual-regression.md
+++ b/docs/visual-regression.md
@@ -24,7 +24,16 @@ Before releasing the docs app and component package, verify visual baselines acr
 - raw color나 theme name 분기 없이 `--ds-*` token이 실제 색상 변화를 담당합니다. / `--ds-*` tokens drive color changes without raw colors or theme-name branches.
 - screenshot 차이가 생기면 의도한 변경인지 PR description에 적습니다. / If screenshots differ, document whether the change is intentional in the PR description.
 
-## 자동화 후보 / Automation Candidate
+## 자동화 / Automation
 
-- Playwright screenshot 검증은 별도 이슈에서 도입합니다. / Introduce Playwright screenshot validation in a separate issue.
-- 첫 자동화 범위는 docs app home, theme compare, DataGrid example 세 화면으로 제한합니다. / Limit the first automated scope to docs app home, theme compare, and DataGrid example screens.
+Playwright screenshot 검증은 `npm run test:visual`로 실행합니다.
+Run Playwright screenshot validation with `npm run test:visual`.
+
+- 첫 자동화 범위는 docs app home, theme compare, DataGrid example 세 화면입니다. / The first automated scope covers docs app home, theme compare, and DataGrid example screens.
+- NORMAL/DARK theme와 mobile/tablet/desktop viewport 조합을 screenshot으로 저장합니다. / Stores screenshots for NORMAL/DARK themes across mobile/tablet/desktop viewports.
+- 산출물은 `artifacts/visual-regression`에 생성되고 CI에서는 artifact로 업로드됩니다. / Outputs are generated in `artifacts/visual-regression` and uploaded as CI artifacts.
+- 현재 단계는 screenshot artifact와 layout overflow 검증을 수행하고, pixel baseline comparison은 별도 기준이 안정화되면 추가합니다. / This stage performs screenshot artifact and layout overflow checks; pixel baseline comparison should be added after baseline criteria stabilize.
+
+```bash
+npm run test:visual
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "jsdom": "^29.1.0"
+        "jsdom": "^29.1.0",
+        "playwright": "^1.59.1"
       },
       "engines": {
         "node": ">=18"
@@ -1676,6 +1677,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:a11y": "npm run build && tsx scripts/accessibility-smoke.mjs",
     "test:interaction": "npm run build && tsx scripts/interaction-a11y.mjs",
     "test:exports": "npm run build && tsx scripts/verify-package-exports.mjs",
+    "test:visual": "node scripts/visual-regression.mjs",
     "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck"
   },
   "dependencies": {
@@ -33,7 +34,8 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "jsdom": "^29.1.0"
+    "jsdom": "^29.1.0",
+    "playwright": "^1.59.1"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/visual-regression.mjs
+++ b/scripts/visual-regression.mjs
@@ -1,0 +1,128 @@
+import { mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { chromium } from "playwright";
+
+const port = 4173;
+const baseUrl = `http://127.0.0.1:${port}`;
+const outputDir = join("artifacts", "visual-regression");
+const pageTimeout = 10_000;
+const viewports = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1440, height: 960 }
+];
+const themes = ["normal", "dark"];
+const targets = [
+  { name: "home", hash: "", selector: ".intro" },
+  { name: "theme-compare", hash: "#themes", selector: ".theme-compare" },
+  { name: "data-grid", hash: "#component-data-grid", selector: "#component-data-grid" }
+];
+
+const failures = [];
+
+function startDocsServer() {
+  return spawn("npm", ["--workspace", "@workspace/docs", "run", "dev", "--", "--host", "127.0.0.1", "--port", String(port)], {
+    env: { ...process.env, BROWSER: "none" },
+    detached: process.platform !== "win32",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}
+
+async function stopDocsServer(server) {
+  if (server.exitCode !== null) return;
+  if (process.platform === "win32" || !server.pid) {
+    server.kill("SIGTERM");
+  } else {
+    process.kill(-server.pid, "SIGTERM");
+  }
+  await Promise.race([
+    new Promise((resolve) => server.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 3_000))
+  ]);
+}
+
+async function waitForServer(server) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 30_000) {
+    if (server.exitCode !== null) break;
+    try {
+      const response = await fetch(baseUrl);
+      if (response.ok) return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  throw new Error("문서 앱 서버가 30초 안에 시작되지 않았습니다. / Docs app server did not start within 30 seconds.");
+}
+
+async function assertLayout(page, target) {
+  const result = await page.evaluate((selector) => {
+    const targetElement = document.querySelector(selector);
+    const targetRect = targetElement?.getBoundingClientRect();
+    const root = document.documentElement;
+    return {
+      hasTarget: Boolean(targetElement),
+      targetWidth: targetRect?.width ?? 0,
+      targetHeight: targetRect?.height ?? 0,
+      pageOverflow: root.scrollWidth - window.innerWidth
+    };
+  }, target.selector);
+
+  if (!result.hasTarget) failures.push(`${target.name}: 대상 selector를 찾지 못했습니다. / Target selector was not found.`);
+  if (result.targetWidth <= 0 || result.targetHeight <= 0) failures.push(`${target.name}: screenshot 대상 크기가 비어 있습니다. / Screenshot target has an empty size.`);
+  if (result.pageOverflow > 4) failures.push(`${target.name}: page horizontal overflow ${result.pageOverflow}px. / Page has horizontal overflow ${result.pageOverflow}px.`);
+}
+
+async function captureTarget(page, target, viewport, theme) {
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.goto(`${baseUrl}/${target.hash}`, { waitUntil: "domcontentloaded", timeout: pageTimeout });
+  await page.waitForLoadState("networkidle", { timeout: 1_000 }).catch(() => undefined);
+  await page.evaluate((themeId) => {
+    document.documentElement.dataset.dsTheme = themeId;
+    document.querySelector(".shell")?.setAttribute("data-ds-theme", themeId);
+  }, theme);
+
+  const locator = page.locator(target.selector).first();
+  await locator.waitFor({ state: "visible" });
+  await assertLayout(page, target);
+
+  const screenshotPath = join(outputDir, `${target.name}-${viewport.name}-${theme}.png`);
+  await locator.screenshot({ path: screenshotPath, animations: "disabled" });
+  const screenshotStat = await stat(screenshotPath);
+  if (screenshotStat.size < 5_000) {
+    failures.push(`${target.name}/${viewport.name}/${theme}: screenshot 파일이 너무 작습니다. / Screenshot file is unexpectedly small.`);
+  }
+}
+
+await rm(outputDir, { force: true, recursive: true });
+await mkdir(outputDir, { recursive: true });
+
+const server = startDocsServer();
+let browser;
+
+try {
+  await waitForServer(server);
+  browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.setDefaultTimeout(pageTimeout);
+  page.setDefaultNavigationTimeout(pageTimeout);
+
+  for (const viewport of viewports) {
+    for (const theme of themes) {
+      for (const target of targets) {
+        await captureTarget(page, target, viewport, theme);
+      }
+    }
+  }
+} finally {
+  await browser?.close();
+  await stopDocsServer(server);
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+
+console.log(`시각 회귀 screenshot ${viewports.length * themes.length * targets.length}개를 생성했습니다. / Generated ${viewports.length * themes.length * targets.length} visual regression screenshots.`);


### PR DESCRIPTION
## 변경 사항 / Changes
- Playwright 기반 docs app screenshot 검증 스크립트를 추가했습니다. / Added a Playwright-based docs app screenshot validation script.
- NORMAL/DARK theme와 mobile/tablet/desktop viewport 조합에서 home, theme compare, DataGrid target을 캡처합니다. / Captures home, theme compare, and DataGrid targets across NORMAL/DARK themes and mobile/tablet/desktop viewports.
- CI에서 Chromium 설치, `npm run test:visual`, screenshot artifact 업로드를 실행하도록 구성했습니다. / Configured CI to install Chromium, run `npm run test:visual`, and upload screenshot artifacts.
- docs app preview/table overflow를 보정해 모바일 가로 스크롤 회귀를 잡았습니다. / Fixed docs app preview/table overflow so mobile horizontal scroll regressions are caught.
- README, release checklist, visual regression 문서를 갱신했습니다. / Updated README, release checklist, and visual regression docs.

## 검증 / Verification
- `npm run test`
- `npm run typecheck`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

## 후속 기준 / Follow-up Criteria
- 현재 단계는 screenshot 생성, target 존재/크기, horizontal overflow 검증까지 포함합니다. / This stage includes screenshot generation, target existence/size, and horizontal overflow checks.
- pixel baseline comparison은 baseline 승인 기준이 안정화된 뒤 별도 이슈로 확장합니다. / Pixel baseline comparison should be expanded in a separate issue after baseline approval criteria stabilize.

Closes #15
