### PR TITLE
[codex] Expand interaction accessibility coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes are documented in this file.
 - 시각 회귀, 릴리즈 정책, 브랜치 보호 기준 문서를 추가했습니다. / Added visual regression, release policy, and branch protection criteria docs.
 - UI package build 전에 stale `dist`를 정리하는 스크립트를 추가했습니다. / Added a script that cleans stale `dist` output before building the UI package.
 - Playwright 기반 docs app screenshot 검증을 추가했습니다. / Added Playwright-based docs app screenshot validation.
+- 상호작용 접근성 검증 범위를 Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, SideNav로 확장했습니다. / Expanded interaction accessibility validation to Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, and SideNav.
 
 ### Changed
 

--- a/docs/accessibility-checklist.md
+++ b/docs/accessibility-checklist.md
@@ -27,3 +27,11 @@
 - color만 유일한 신호로 쓰지 않습니다. / Color is not the only signal.
 - compact layout에서도 touch target size가 허용 가능한 수준입니다. / Touch target size is acceptable for compact layouts.
 - high contrast mode에서 필수 boundary가 사라지지 않습니다. / High contrast mode does not lose essential boundaries.
+
+## 회귀 테스트 기준 / Regression Test Criteria
+
+- `scripts/interaction-a11y.mjs`는 `componentCatalog` 기준 상호작용 컴포넌트 목록이 누락되지 않는지 먼저 확인합니다. / `scripts/interaction-a11y.mjs` first verifies that the interaction component list is present in `componentCatalog`.
+- JSDOM에서는 native `select`, `input[type="date"]`, `input[type="file"]`의 브라우저 UI 자체를 열 수 없으므로 focus 유지, value 변경, callback, rendered state를 검증합니다. / JSDOM cannot open native browser UI for `select`, `input[type="date"]`, or `input[type="file"]`, so tests verify focus retention, value changes, callbacks, and rendered state.
+- custom navigation pattern은 Arrow, Home, End, Space, Enter 흐름을 테스트에 포함합니다. / Custom navigation patterns include Arrow, Home, End, Space, and Enter flows in tests.
+- Escape로 닫히는 overlay는 focus return을 반드시 검증합니다. / Overlays that close with Escape must verify focus return.
+- 실제 브라우저 layout, native picker popup, drag-and-drop pointer detail은 Playwright visual/browser test 범위로 분리합니다. / Real browser layout, native picker popups, and drag-and-drop pointer details belong in Playwright visual/browser tests.

--- a/packages/ui/src/components/navigation/navigation-rail/navigation-rail.tsx
+++ b/packages/ui/src/components/navigation/navigation-rail/navigation-rail.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import { useRef, type HTMLAttributes, type KeyboardEvent, type ReactNode } from "react";
 import { useControllableState } from "../../../shared/use-controllable-state";
 import { classNames } from "../../../shared/utils";
 
@@ -21,11 +21,48 @@ export interface NavigationRailProps extends Omit<HTMLAttributes<HTMLElement>, "
 
 export function NavigationRail({ items = [], value, defaultValue, label = "주요 내비게이션 / Primary navigation", collapsed = false, onValueChange, className, ...props }: NavigationRailProps) {
   const [currentValue, setCurrentValue] = useControllableState({ value, defaultValue: defaultValue ?? items[0]?.value ?? "", onChange: onValueChange });
+  const navRef = useRef<HTMLElement>(null);
+  const enabledItems = items
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => !item.disabled);
+  const focusItem = (enabledIndex: number) => {
+    const nextIndex = (enabledIndex + enabledItems.length) % enabledItems.length;
+    const nextItem = enabledItems[nextIndex];
+    if (!nextItem) return;
+    navRef.current?.querySelectorAll<HTMLElement>(".ds-NavigationRail-item:not(:disabled)")[nextIndex]?.focus();
+  };
+  const onItemKeyDown = (event: KeyboardEvent<HTMLElement>, item: NavigationRailItem, index: number) => {
+    const enabledIndex = enabledItems.findIndex((enabledItem) => enabledItem.index === index);
+    if (enabledIndex < 0) return;
+    if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusItem(enabledIndex - 1);
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+      event.preventDefault();
+      focusItem(enabledIndex + 1);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      focusItem(0);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      focusItem(enabledItems.length - 1);
+    }
+    if (event.key === "Enter") {
+      setCurrentValue(item.value);
+    }
+    if (event.key === " ") {
+      event.preventDefault();
+      setCurrentValue(item.value);
+    }
+  };
 
   return (
-    <nav className={classNames("ds-NavigationRail", className)} data-collapsed={collapsed ? "true" : undefined} aria-label={label} {...props}>
+    <nav className={classNames("ds-NavigationRail", className)} data-collapsed={collapsed ? "true" : undefined} aria-label={label} ref={navRef} {...props}>
       <ul className="ds-NavigationRail-list">
-        {items.map((item) => {
+        {items.map((item, index) => {
           const selected = item.value === currentValue;
           const content = (
             <>
@@ -36,9 +73,9 @@ export function NavigationRail({ items = [], value, defaultValue, label = "주�
           return (
             <li key={item.value}>
               {item.href ? (
-                <a className="ds-NavigationRail-item" data-selected={selected ? "true" : undefined} aria-current={selected ? "page" : undefined} href={item.href} onClick={() => setCurrentValue(item.value)}>{content}</a>
+                <a className="ds-NavigationRail-item" data-selected={selected ? "true" : undefined} aria-current={selected ? "page" : undefined} href={item.href} onClick={() => setCurrentValue(item.value)} onKeyDown={(event) => onItemKeyDown(event, item, index)}>{content}</a>
               ) : (
-                <button className="ds-NavigationRail-item" data-selected={selected ? "true" : undefined} disabled={item.disabled} type="button" onClick={() => setCurrentValue(item.value)}>{content}</button>
+                <button className="ds-NavigationRail-item" data-selected={selected ? "true" : undefined} disabled={item.disabled} type="button" onClick={() => setCurrentValue(item.value)} onKeyDown={(event) => onItemKeyDown(event, item, index)}>{content}</button>
               )}
             </li>
           );

--- a/packages/ui/src/components/navigation/side-nav/side-nav.tsx
+++ b/packages/ui/src/components/navigation/side-nav/side-nav.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import { useRef, type HTMLAttributes, type KeyboardEvent, type ReactNode } from "react";
 import { useControllableState } from "../../../shared/use-controllable-state";
 import { classNames } from "../../../shared/utils";
 
@@ -26,16 +26,57 @@ export interface SideNavProps extends Omit<HTMLAttributes<HTMLElement>, "default
 }
 
 export function SideNav({ sections = [], value, defaultValue, label = "사이드 내비게이션 / Side navigation", collapsible = false, collapsed = false, onValueChange, className, ...props }: SideNavProps) {
-  const fallbackValue = defaultValue ?? sections.flatMap((section) => section.items)[0]?.value ?? "";
+  const flatItems = sections.flatMap((section) => section.items);
+  const fallbackValue = defaultValue ?? flatItems[0]?.value ?? "";
   const [currentValue, setCurrentValue] = useControllableState({ value, defaultValue: fallbackValue, onChange: onValueChange });
+  const navRef = useRef<HTMLElement>(null);
+  const enabledItems = flatItems
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => !item.disabled);
+  const focusItem = (enabledIndex: number) => {
+    const nextIndex = (enabledIndex + enabledItems.length) % enabledItems.length;
+    const nextItem = enabledItems[nextIndex];
+    if (!nextItem) return;
+    navRef.current?.querySelectorAll<HTMLElement>(".ds-SideNav-item:not(:disabled)")[nextIndex]?.focus();
+  };
+  const onItemKeyDown = (event: KeyboardEvent<HTMLElement>, item: SideNavItem, flatIndex: number) => {
+    const enabledIndex = enabledItems.findIndex((enabledItem) => enabledItem.index === flatIndex);
+    if (enabledIndex < 0) return;
+    if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+      event.preventDefault();
+      focusItem(enabledIndex - 1);
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+      event.preventDefault();
+      focusItem(enabledIndex + 1);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      focusItem(0);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      focusItem(enabledItems.length - 1);
+    }
+    if (event.key === "Enter") {
+      setCurrentValue(item.value);
+    }
+    if (event.key === " ") {
+      event.preventDefault();
+      setCurrentValue(item.value);
+    }
+  };
+  let flatIndex = 0;
 
   return (
-    <nav className={classNames("ds-SideNav", className)} data-collapsible={collapsible ? "true" : undefined} data-collapsed={collapsed ? "true" : undefined} aria-label={label} {...props}>
+    <nav className={classNames("ds-SideNav", className)} data-collapsible={collapsible ? "true" : undefined} data-collapsed={collapsed ? "true" : undefined} aria-label={label} ref={navRef} {...props}>
       {sections.map((section, sectionIndex) => (
         <div className="ds-SideNav-section" key={sectionIndex}>
           {section.title ? <strong className="ds-SideNav-title">{section.title}</strong> : null}
           <ul className="ds-SideNav-list">
             {section.items.map((item) => {
+              const itemIndex = flatIndex;
+              flatIndex += 1;
               const selected = item.value === currentValue;
               const content = (
                 <>
@@ -46,9 +87,9 @@ export function SideNav({ sections = [], value, defaultValue, label = "사이드
               return (
                 <li key={item.value}>
                   {item.href ? (
-                    <a className="ds-SideNav-item" data-selected={selected ? "true" : undefined} aria-current={selected ? "page" : undefined} href={item.href} onClick={() => setCurrentValue(item.value)}>{content}</a>
+                    <a className="ds-SideNav-item" data-selected={selected ? "true" : undefined} aria-current={selected ? "page" : undefined} href={item.href} onClick={() => setCurrentValue(item.value)} onKeyDown={(event) => onItemKeyDown(event, item, itemIndex)}>{content}</a>
                   ) : (
-                    <button className="ds-SideNav-item" data-selected={selected ? "true" : undefined} disabled={item.disabled} type="button" onClick={() => setCurrentValue(item.value)}>{content}</button>
+                    <button className="ds-SideNav-item" data-selected={selected ? "true" : undefined} disabled={item.disabled} type="button" onClick={() => setCurrentValue(item.value)} onKeyDown={(event) => onItemKeyDown(event, item, itemIndex)}>{content}</button>
                   )}
                 </li>
               );

--- a/packages/ui/src/components/navigation/stepper/stepper.tsx
+++ b/packages/ui/src/components/navigation/stepper/stepper.tsx
@@ -51,6 +51,10 @@ export function Stepper({ steps = [], value, defaultValue, orientation = "horizo
       event.preventDefault();
       focusStep(steps.length - 1);
     }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setCurrentValue(steps[index]?.value ?? currentValue);
+    }
   };
 
   return (

--- a/packages/ui/src/components/navigation/tabs/tabs.tsx
+++ b/packages/ui/src/components/navigation/tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import { useId, type HTMLAttributes, type ReactNode } from "react";
+import { useId, useRef, type HTMLAttributes, type KeyboardEvent, type ReactNode } from "react";
 import { classNames } from "../../../shared/utils";
 import { useControllableState } from "../../../shared/use-controllable-state";
 
@@ -42,14 +42,51 @@ export function Tabs({
     onChange: onValueChange
   });
   const baseId = useId();
+  const tabListRef = useRef<HTMLDivElement>(null);
+  const enabledItems = items
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => !item.disabled);
   const activate = (nextValue: string) => {
     setSelectedValue(nextValue);
+  };
+  const focusTab = (enabledIndex: number) => {
+    const nextIndex = (enabledIndex + enabledItems.length) % enabledItems.length;
+    const nextItem = enabledItems[nextIndex];
+    if (!nextItem) return;
+    tabListRef.current?.querySelectorAll<HTMLButtonElement>(".ds-Tabs-tab:not(:disabled)")[nextIndex]?.focus();
+    if (activationMode === "automatic") activate(nextItem.item.value);
+  };
+  const onTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number, nextValue: string) => {
+    const enabledIndex = enabledItems.findIndex((item) => item.index === index);
+    const previousKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft";
+    const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight";
+    if (enabledIndex < 0) return;
+    if (event.key === previousKey) {
+      event.preventDefault();
+      focusTab(enabledIndex - 1);
+    }
+    if (event.key === nextKey) {
+      event.preventDefault();
+      focusTab(enabledIndex + 1);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      focusTab(0);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      focusTab(enabledItems.length - 1);
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      activate(nextValue);
+    }
   };
 
   return (
     <div className={classNames("ds-Tabs", className)} data-orientation={orientation} data-activation-mode={activationMode} data-variant={variant} data-size={size} data-full-width={fullWidth ? "true" : undefined} {...props}>
-      <div className="ds-Tabs-list" role="tablist" aria-orientation={orientation}>
-        {items.map((item) => {
+      <div className="ds-Tabs-list" role="tablist" aria-orientation={orientation} ref={tabListRef}>
+        {items.map((item, index) => {
           const selected = item.value === selectedValue;
           return (
             <button
@@ -63,6 +100,7 @@ export function Tabs({
               aria-selected={selected}
               tabIndex={selected ? 0 : -1}
               onClick={() => activate(item.value)}
+              onKeyDown={(event) => onTabKeyDown(event, index, item.value)}
             >
               {item.label}
             </button>

--- a/scripts/interaction-a11y.mjs
+++ b/scripts/interaction-a11y.mjs
@@ -11,6 +11,7 @@ globalThis.document = dom.window.document;
 globalThis.HTMLElement = dom.window.HTMLElement;
 globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;
 globalThis.HTMLDialogElement = dom.window.HTMLDialogElement;
+globalThis.File = dom.window.File;
 globalThis.KeyboardEvent = dom.window.KeyboardEvent;
 globalThis.MouseEvent = dom.window.MouseEvent;
 globalThis.Node = dom.window.Node;
@@ -46,12 +47,35 @@ const {
   Combobox,
   CommandPalette,
   DataGrid,
+  DatePicker,
   Dialog,
   DropdownMenu,
-  Popover
+  FileUploader,
+  NavigationRail,
+  Popover,
+  Select,
+  SideNav,
+  Stepper,
+  Tabs,
+  componentCatalog
 } = await import("../packages/ui/dist/index.js");
 
 const failures = [];
+const interactionCoverageNames = [
+  "Select",
+  "DatePicker",
+  "Combobox",
+  "FileUploader",
+  "CommandPalette",
+  "DropdownMenu",
+  "Popover",
+  "Dialog",
+  "Tabs",
+  "Stepper",
+  "NavigationRail",
+  "SideNav",
+  "DataGrid"
+];
 
 async function check(name, fn) {
   try {
@@ -63,6 +87,53 @@ async function check(name, fn) {
     cleanup();
   }
 }
+
+await check("Catalog interaction coverage list", async () => {
+  const catalogNames = new Set(componentCatalog.map((item) => item.name));
+  const missingNames = interactionCoverageNames.filter((name) => !catalogNames.has(name));
+  if (missingNames.length > 0) {
+    throw new Error(`Expected interactive components in catalog, missing: ${missingNames.join(", ")}`);
+  }
+});
+
+await check("Select focus and keyboard value change", async () => {
+  render(React.createElement(Select, {
+    label: "상태 / Status",
+    defaultValue: "draft",
+    options: [
+      { label: "초안 / Draft", value: "draft" },
+      { label: "준비 / Ready", value: "ready" }
+    ]
+  }));
+
+  const select = screen.getByRole("combobox", { name: "상태 / Status" });
+  select.focus();
+  fireEvent.keyDown(select, { key: "ArrowDown" });
+  fireEvent.change(select, { target: { value: "ready" } });
+
+  await waitFor(() => {
+    if (document.activeElement !== select) throw new Error("Expected select to keep focus during keyboard selection.");
+    if (select.value !== "ready") throw new Error(`Expected selected value "ready", received: ${select.value}`);
+  });
+});
+
+await check("DatePicker focus and Enter commit", async () => {
+  render(React.createElement(DatePicker, {
+    label: "시작일 / Start date",
+    minDate: "2026-01-01",
+    maxDate: "2026-12-31"
+  }));
+
+  const input = screen.getByLabelText("시작일 / Start date");
+  input.focus();
+  fireEvent.change(input, { target: { value: "2026-04-29" } });
+  fireEvent.keyDown(input, { key: "Enter" });
+
+  await waitFor(() => {
+    if (document.activeElement !== input) throw new Error("Expected date input to keep focus after Enter.");
+    if (input.value !== "2026-04-29") throw new Error(`Expected date value to be committed, received: ${input.value}`);
+  });
+});
 
 await check("Combobox keyboard selection", async () => {
   render(React.createElement(Combobox, {
@@ -90,6 +161,27 @@ await check("Combobox keyboard selection", async () => {
   });
 });
 
+await check("FileUploader file selection", async () => {
+  const file = new File(["component"], "component-spec.md", { type: "text/markdown" });
+  let selectedFiles = [];
+  render(React.createElement(FileUploader, {
+    label: "첨부 / Attachment",
+    onFilesChange: (files) => {
+      selectedFiles = files;
+    }
+  }));
+
+  const input = screen.getByLabelText("첨부 / Attachment");
+  input.focus();
+  fireEvent.change(input, { target: { files: [file] } });
+
+  await waitFor(() => {
+    if (document.activeElement !== input) throw new Error("Expected file input to keep focus after file selection.");
+    if (selectedFiles[0]?.name !== "component-spec.md") throw new Error("Expected selected file to be reported.");
+    if (!screen.getByText("component-spec.md")) throw new Error("Expected selected file name to be rendered.");
+  });
+});
+
 await check("CommandPalette keyboard selection", async () => {
   let selected = "";
   const user = userEvent.setup();
@@ -110,6 +202,133 @@ await check("CommandPalette keyboard selection", async () => {
 
   await waitFor(() => {
     if (selected !== "new") throw new Error(`Expected command "new", received: ${selected}`);
+  });
+});
+
+await check("Tabs arrow navigation and Space activation", async () => {
+  let selected = "overview";
+  render(React.createElement(Tabs, {
+    activationMode: "manual",
+    defaultValue: "overview",
+    onValueChange: (value) => {
+      selected = value;
+    },
+    items: [
+      { label: "개요 / Overview", value: "overview", content: "Overview" },
+      { label: "API", value: "api", content: "API" },
+      { label: "예시 / Examples", value: "examples", content: "Examples" }
+    ]
+  }));
+
+  const overviewTab = screen.getByRole("tab", { name: "개요 / Overview" });
+  overviewTab.focus();
+  fireEvent.keyDown(overviewTab, { key: "ArrowRight" });
+
+  const apiTab = screen.getByRole("tab", { name: "API" });
+  await waitFor(() => {
+    if (document.activeElement !== apiTab) throw new Error("Expected ArrowRight to move focus to the next tab.");
+    if (selected !== "overview") throw new Error("Expected manual tabs to defer activation until Space or Enter.");
+  });
+
+  fireEvent.keyDown(apiTab, { key: " " });
+  await waitFor(() => {
+    if (selected !== "api") throw new Error(`Expected Space to activate API tab, received: ${selected}`);
+    if (apiTab.getAttribute("aria-selected") !== "true") throw new Error("Expected activated tab to expose aria-selected.");
+  });
+});
+
+await check("Stepper arrow navigation and Enter activation", async () => {
+  let selected = "requirements";
+  render(React.createElement(Stepper, {
+    defaultValue: "requirements",
+    onValueChange: (value) => {
+      selected = value;
+    },
+    steps: [
+      { label: "요구사항 / Requirements", value: "requirements" },
+      { label: "API", value: "api" },
+      { label: "검증 / Verify", value: "verify" }
+    ]
+  }));
+
+  const requirementsStep = screen.getByRole("button", { name: /요구사항 \/ Requirements/ });
+  requirementsStep.focus();
+  fireEvent.keyDown(requirementsStep, { key: "ArrowRight" });
+
+  const apiStep = screen.getByRole("button", { name: /API/ });
+  await waitFor(() => {
+    if (document.activeElement !== apiStep) throw new Error("Expected ArrowRight to move focus to the next step.");
+    if (selected !== "api") throw new Error(`Expected arrow navigation to activate API step, received: ${selected}`);
+  });
+
+  fireEvent.keyDown(apiStep, { key: "Enter" });
+  await waitFor(() => {
+    if (apiStep.getAttribute("aria-current") !== "step") throw new Error("Expected active step to expose aria-current.");
+  });
+});
+
+await check("NavigationRail arrow navigation and Space activation", async () => {
+  let selected = "home";
+  render(React.createElement(NavigationRail, {
+    defaultValue: "home",
+    onValueChange: (value) => {
+      selected = value;
+    },
+    items: [
+      { label: "홈 / Home", value: "home", icon: "H" },
+      { label: "컴포넌트 / Components", value: "components", icon: "C" },
+      { label: "문서 / Docs", value: "docs", icon: "D" }
+    ]
+  }));
+
+  const homeItem = screen.getByRole("button", { name: "홈 / Home" });
+  homeItem.focus();
+  fireEvent.keyDown(homeItem, { key: "ArrowDown" });
+
+  const componentItem = screen.getByRole("button", { name: "컴포넌트 / Components" });
+  await waitFor(() => {
+    if (document.activeElement !== componentItem) throw new Error("Expected ArrowDown to move focus to the next rail item.");
+  });
+
+  fireEvent.keyDown(componentItem, { key: " " });
+  await waitFor(() => {
+    if (selected !== "components") throw new Error(`Expected Space to activate components item, received: ${selected}`);
+    if (componentItem.getAttribute("data-selected") !== "true") throw new Error("Expected selected rail item to expose data-selected.");
+  });
+});
+
+await check("SideNav arrow navigation and Enter activation", async () => {
+  let selected = "overview";
+  render(React.createElement(SideNav, {
+    defaultValue: "overview",
+    onValueChange: (value) => {
+      selected = value;
+    },
+    sections: [
+      {
+        title: "문서 / Docs",
+        items: [
+          { label: "개요 / Overview", value: "overview" },
+          { label: "Prop API", value: "props" },
+          { label: "릴리즈 / Release", value: "release" }
+        ]
+      }
+    ]
+  }));
+
+  const overviewItem = screen.getByRole("button", { name: "개요 / Overview" });
+  overviewItem.focus();
+  fireEvent.keyDown(overviewItem, { key: "ArrowDown" });
+
+  const propsItem = screen.getByRole("button", { name: "Prop API" });
+  await waitFor(() => {
+    if (document.activeElement !== propsItem) throw new Error("Expected ArrowDown to move focus to the next side nav item.");
+  });
+
+  fireEvent.keyDown(propsItem, { key: "Enter" });
+  await waitFor(() => {
+    if (selected !== "props") throw new Error(`Expected Enter to activate props item, received: ${selected}`);
+    if (propsItem.getAttribute("data-selected") !== "true") throw new Error("Expected selected side nav item to expose data-selected.");
   });
 });
 


### PR DESCRIPTION
## 변경 사항 / Changes
- `scripts/interaction-a11y.mjs`가 `componentCatalog` 기준 상호작용 커버리지 목록을 확인하도록 확장했습니다. / Expanded `scripts/interaction-a11y.mjs` to verify the interaction coverage list against `componentCatalog`.
- Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, SideNav keyboard/focus regression checks를 추가했습니다. / Added keyboard/focus regression checks for Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, and SideNav.
- Tabs에 Arrow/Home/End roving focus와 Space/Enter activation을 추가했습니다. / Added Arrow/Home/End roving focus and Space/Enter activation to Tabs.
- Stepper, NavigationRail, SideNav의 keyboard activation/navigation을 보강했습니다. / Hardened keyboard activation/navigation for Stepper, NavigationRail, and SideNav.
- JSDOM 한계와 Playwright 분리 기준을 접근성 체크리스트에 문서화했습니다. / Documented JSDOM limits and Playwright split criteria in the accessibility checklist.

## 검증 / Verification
- `npm run test`
- `npm run typecheck`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

Closes #16
