### PR TITLE
[codex] Add package consumer fixture validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: 문서 앱 빌드 / Build docs app
         run: npm --workspace @workspace/docs run build
 
+      - name: 소비자 fixture 빌드 / Build consumer fixture
+        run: npm run test:consumer
+
       - name: Playwright 브라우저 설치 / Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes are documented in this file.
 - UI package build 전에 stale `dist`를 정리하는 스크립트를 추가했습니다. / Added a script that cleans stale `dist` output before building the UI package.
 - Playwright 기반 docs app screenshot 검증을 추가했습니다. / Added Playwright-based docs app screenshot validation.
 - 상호작용 접근성 검증 범위를 Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, SideNav로 확장했습니다. / Expanded interaction accessibility validation to Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, and SideNav.
+- 외부 소비자 fixture 앱과 `test:consumer` 검증을 추가했습니다. / Added an external consumer fixture app and `test:consumer` validation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ npm run test
 Runs component system validation, UI build, accessibility smoke checks, interaction accessibility checks, and package export verification together.
 
 ```bash
+npm run test:consumer
+```
+
+빌드된 `@workspace/ui` package export를 source alias 없이 소비자 fixture 앱에서 import하고 build합니다.
+Builds the consumer fixture app against built `@workspace/ui` package exports without source aliases.
+
+```bash
 npm run test:visual
 ```
 

--- a/apps/consumer-fixture/index.html
+++ b/apps/consumer-fixture/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>소비자 Fixture / Consumer Fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/consumer-fixture/package.json
+++ b/apps/consumer-fixture/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@workspace/consumer-fixture",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "npm run typecheck && vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@workspace/tokens": "0.1.0",
+    "@workspace/ui": "0.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/apps/consumer-fixture/src/main.tsx
+++ b/apps/consumer-fixture/src/main.tsx
@@ -1,0 +1,59 @@
+import "@workspace/tokens/tokens.css";
+import "@workspace/ui/styles.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { Badge, Button, Card, DataGrid, Stack, TextField, componentCatalog } from "@workspace/ui";
+import { Button as ButtonEntry } from "@workspace/ui/components/actions/button";
+import { DataGrid as DataGridEntry } from "@workspace/ui/components/data-display/data-grid";
+
+const rows = [
+  { id: "ready", name: "Root export", status: "통과 / Pass" },
+  { id: "entry", name: "Per-component export", status: "통과 / Pass" }
+];
+
+function ConsumerFixture() {
+  return (
+    <main data-ds-theme="dark" style={{ padding: "24px" }}>
+      <Stack gap="md">
+        <Card
+          eyebrow="외부 소비자 / External consumer"
+          title="패키지 import 검증 / Package import verification"
+          description={`catalog ${componentCatalog.length}개 항목을 root export에서 읽었습니다. / Read ${componentCatalog.length} catalog items from the root export.`}
+          actions={[{ label: "Root action", variant: "outline", tone: "neutral" }]}
+        >
+          <Stack gap="sm">
+            <TextField label="토큰 적용 / Token applied" defaultValue="data-ds-theme=dark" width="full" />
+            <Button>Root Button</Button>
+            <ButtonEntry variant="outline" tone="neutral">Entry Button</ButtonEntry>
+            <Badge label="styles.css imported" tone="success" />
+          </Stack>
+        </Card>
+        <DataGrid
+          caption="Root DataGrid"
+          columns={[
+            { key: "name", label: "이름 / Name" },
+            { key: "status", label: "상태 / Status" }
+          ]}
+          rows={rows}
+          rowKey={(row) => row.id}
+        />
+        <DataGridEntry
+          caption="Entry DataGrid"
+          columns={[
+            { key: "name", label: "이름 / Name" },
+            { key: "status", label: "상태 / Status" }
+          ]}
+          rows={rows}
+          rowKey={(row) => row.id}
+        />
+      </Stack>
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConsumerFixture />
+  </StrictMode>
+);

--- a/apps/consumer-fixture/tsconfig.json
+++ b/apps/consumer-fixture/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/apps/consumer-fixture/vite.config.ts
+++ b/apps/consumer-fixture/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "dist"
+  }
+});

--- a/docs/package-consumption.md
+++ b/docs/package-consumption.md
@@ -107,6 +107,19 @@ packages/ui/dist/
 export 경로는 릴리즈 전에 `npm run test:exports`로 확인합니다.
 Validate export paths before release with `npm run test:exports`.
 
+## 소비자 fixture / Consumer Fixture
+
+`apps/consumer-fixture`는 source alias 없이 빌드된 package entry를 가져오는 Vite 앱입니다.
+`apps/consumer-fixture` is a Vite app that consumes built package entries without source aliases.
+
+```bash
+npm run test:consumer
+```
+
+- root export에서 `Button`, `Card`, `DataGrid`, `TextField`, `componentCatalog`를 가져옵니다. / Imports `Button`, `Card`, `DataGrid`, `TextField`, and `componentCatalog` from the root export.
+- per-component export에서 `Button`과 `DataGrid`를 가져옵니다. / Imports `Button` and `DataGrid` from per-component exports.
+- `@workspace/tokens/tokens.css`와 `@workspace/ui/styles.css`를 함께 import하고 `data-ds-theme="dark"`에서 build가 통과해야 합니다. / Imports `@workspace/tokens/tokens.css` with `@workspace/ui/styles.css`, and the build must pass with `data-ds-theme="dark"`.
+
 ## API 상태 제어 / API State Control
 
 상태를 외부에서 제어해야 하는 화면은 controlled prop과 `on*Change` callback을 함께 사용합니다.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -11,6 +11,7 @@ npm run test
 npm run typecheck
 npm run build
 npm --workspace @workspace/docs run build
+npm run test:consumer
 npm run test:visual
 npm pack --workspace @workspace/ui --dry-run
 ```
@@ -22,6 +23,7 @@ npm pack --workspace @workspace/ui --dry-run
 - UI CSS에는 raw color 값을 직접 쓰지 않습니다. / UI CSS must not contain raw color values.
 - `test:a11y`는 핵심 accessible markup을 server render 기준으로 확인해야 합니다. / `test:a11y` must verify core accessible markup through server rendering.
 - `test:interaction`은 keyboard, focus return, highlighted option 같은 상호작용 접근성 흐름을 확인해야 합니다. / `test:interaction` must verify interaction accessibility flows such as keyboard, focus return, and highlighted options.
+- `test:consumer`는 source alias 없이 `@workspace/ui` root export, per-component export, `styles.css`, token CSS import를 fixture 앱에서 확인해야 합니다. / `test:consumer` must verify `@workspace/ui` root exports, per-component exports, `styles.css`, and token CSS imports in the fixture app without source aliases.
 - `test:visual`은 docs app home, theme compare, DataGrid screenshot과 horizontal overflow를 확인해야 합니다. / `test:visual` must verify docs app home, theme compare, DataGrid screenshots, and horizontal overflow.
 - `test:exports`는 root export와 per-component export가 실제 `dist` 파일과 맞는지 확인해야 합니다. / `test:exports` must verify that root and per-component exports match real `dist` files.
 - React는 dependency가 아니라 peer dependency로 유지합니다. / React must remain a peer dependency, not a bundled dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,16 @@
         "node": ">=18"
       }
     },
+    "apps/consumer-fixture": {
+      "name": "@workspace/consumer-fixture",
+      "version": "0.1.0",
+      "dependencies": {
+        "@workspace/tokens": "0.1.0",
+        "@workspace/ui": "0.1.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "apps/docs": {
       "name": "@workspace/docs",
       "version": "0.1.0",
@@ -1161,6 +1171,10 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/@workspace/consumer-fixture": {
+      "resolved": "apps/consumer-fixture",
+      "link": true
     },
     "node_modules/@workspace/docs": {
       "resolved": "apps/docs",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "test:a11y": "npm run build && tsx scripts/accessibility-smoke.mjs",
     "test:interaction": "npm run build && tsx scripts/interaction-a11y.mjs",
     "test:exports": "npm run build && tsx scripts/verify-package-exports.mjs",
+    "test:consumer": "npm run build && npm --workspace @workspace/consumer-fixture run build",
     "test:visual": "node scripts/visual-regression.mjs",
-    "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck"
+    "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck && npm --workspace @workspace/consumer-fixture run typecheck"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./packages/ui" },
-    { "path": "./apps/docs" }
+    { "path": "./apps/docs" },
+    { "path": "./apps/consumer-fixture" }
   ]
 }


### PR DESCRIPTION
## 변경 사항 / Changes
- source alias 없이 빌드된 `@workspace/ui` package entry를 소비하는 `apps/consumer-fixture` Vite 앱을 추가했습니다. / Added an `apps/consumer-fixture` Vite app that consumes built `@workspace/ui` package entries without source aliases.
- root export와 per-component export를 모두 import해 build에서 검증합니다. / Verifies both root exports and per-component exports through build.
- `@workspace/tokens/tokens.css`, `@workspace/ui/styles.css`, `data-ds-theme="dark"` 조합을 fixture에서 확인합니다. / Verifies `@workspace/tokens/tokens.css`, `@workspace/ui/styles.css`, and `data-ds-theme="dark"` in the fixture.
- `npm run test:consumer` script, root typecheck 포함, CI fixture build step을 추가했습니다. / Added the `npm run test:consumer` script, root typecheck coverage, and a CI fixture build step.
- README, package consumption guide, release checklist를 갱신했습니다. / Updated README, package consumption guide, and release checklist.

## 검증 / Verification
- `npm run test:consumer`
- `npm run typecheck`
- `npm run test`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

Closes #17
