### PR TITLE
[codex] Add DataGrid keyboard column resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes are documented in this file.
 - Playwright 기반 docs app screenshot 검증을 추가했습니다. / Added Playwright-based docs app screenshot validation.
 - 상호작용 접근성 검증 범위를 Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, SideNav로 확장했습니다. / Expanded interaction accessibility validation to Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, and SideNav.
 - 외부 소비자 fixture 앱과 `test:consumer` 검증을 추가했습니다. / Added an external consumer fixture app and `test:consumer` validation.
+- DataGrid column resize keyboard 조작과 ARIA value 상태를 추가했습니다. / Added DataGrid column resize keyboard controls and ARIA value state.
 
 ### Changed
 

--- a/packages/ui/src/components/data-display/data-grid/README.md
+++ b/packages/ui/src/components/data-display/data-grid/README.md
@@ -34,7 +34,9 @@
 - accessible name이 필요한 control은 `label`, `aria-label`, visible text 중 하나로 이름을 제공합니다. / Controls that need an accessible name receive it through `label`, `aria-label`, or visible text.
 - 행 focus는 roving `tabIndex`로 한 행만 tab stop이 되며 `ArrowUp`, `ArrowDown`, `Home`, `End`로 이동합니다. / Row focus uses roving `tabIndex` so only one row is a tab stop, and `ArrowUp`, `ArrowDown`, `Home`, and `End` move focus.
 - `selectionMode="multiple"`일 때 행 focus 상태에서 Space로 선택을 토글할 수 있습니다. / When `selectionMode="multiple"`, Space toggles selection from the focused row.
-- `resizableColumns`와 column의 `resizable` 설정으로 pointer 기반 열 너비 조절을 제어합니다. / `resizableColumns` and each column's `resizable` setting control pointer-based column resizing.
+- `resizableColumns`와 column의 `resizable` 설정으로 pointer와 keyboard 기반 열 너비 조절을 제어합니다. / `resizableColumns` and each column's `resizable` setting control pointer-based and keyboard-based column resizing.
+- resize handle은 `role="separator"`와 `aria-valuemin`, `aria-valuemax`, `aria-valuenow`를 제공하고 `ArrowLeft`/`ArrowRight`는 16px, `Shift+ArrowLeft`/`Shift+ArrowRight`는 48px 단위로 조절합니다. / Resize handles expose `role="separator"`, `aria-valuemin`, `aria-valuemax`, and `aria-valuenow`; `ArrowLeft`/`ArrowRight` adjust by 16px, while `Shift+ArrowLeft`/`Shift+ArrowRight` adjust by 48px.
+- resize handle에서 `Home`은 최소 너비, `End`는 최대 너비로 이동합니다. / On a resize handle, `Home` moves to the minimum width and `End` moves to the maximum width.
 - focus-visible은 `--ds-focus-ring`을 사용하고 keyboard navigation에서 사라지지 않아야 합니다. / Focus-visible uses `--ds-focus-ring` and must remain visible during keyboard navigation.
 
 ## 토큰 / Tokens

--- a/packages/ui/src/components/data-display/data-grid/data-grid.tsx
+++ b/packages/ui/src/components/data-display/data-grid/data-grid.tsx
@@ -42,6 +42,8 @@ export interface DataGridProps<Row extends Record<string, unknown>> extends HTML
 const DEFAULT_COLUMN_WIDTH = 160;
 const MIN_COLUMN_WIDTH = 96;
 const MAX_COLUMN_WIDTH = 640;
+const COLUMN_RESIZE_STEP = 16;
+const COLUMN_RESIZE_LARGE_STEP = 48;
 
 function toColumnWidth(width: string | undefined) {
   if (!width) return undefined;
@@ -170,17 +172,23 @@ export function DataGrid<Row extends Record<string, unknown>>({
     const width = columnWidths[column.key] ?? toColumnWidth(column.width);
     return width ? { width, minWidth: column.minWidth, maxWidth: column.maxWidth } : { width: column.width, minWidth: column.minWidth, maxWidth: column.maxWidth };
   };
+  const getColumnWidth = (column: DataGridColumn<Row>, fallbackWidth = DEFAULT_COLUMN_WIDTH) => {
+    return clampColumnWidth(column, columnWidths[column.key] ?? toColumnWidth(column.width) ?? fallbackWidth);
+  };
+  const resizeColumn = (column: DataGridColumn<Row>, nextWidth: number) => {
+    const clampedWidth = clampColumnWidth(column, nextWidth);
+    setColumnWidths((currentWidths) => ({ ...currentWidths, [column.key]: clampedWidth }));
+    onColumnResize?.(column.key, clampedWidth);
+  };
   const startColumnResize = (event: ReactPointerEvent<HTMLButtonElement>, column: DataGridColumn<Row>) => {
     if (!resizableColumns || column.resizable === false) return;
 
     event.preventDefault();
     const headerCell = event.currentTarget.closest("th");
     const startX = event.clientX;
-    const startWidth = headerCell?.getBoundingClientRect().width ?? columnWidths[column.key] ?? toColumnWidth(column.width) ?? DEFAULT_COLUMN_WIDTH;
+    const startWidth = getColumnWidth(column, headerCell?.getBoundingClientRect().width);
     const onPointerMove = (pointerEvent: PointerEvent) => {
-      const nextWidth = clampColumnWidth(column, startWidth + pointerEvent.clientX - startX);
-      setColumnWidths((currentWidths) => ({ ...currentWidths, [column.key]: nextWidth }));
-      onColumnResize?.(column.key, nextWidth);
+      resizeColumn(column, startWidth + pointerEvent.clientX - startX);
     };
     const onPointerUp = () => {
       window.removeEventListener("pointermove", onPointerMove);
@@ -189,6 +197,28 @@ export function DataGrid<Row extends Record<string, unknown>>({
 
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("pointerup", onPointerUp);
+  };
+  const onColumnResizeKeyDown = (event: KeyboardEvent<HTMLButtonElement>, column: DataGridColumn<Row>) => {
+    if (!resizableColumns || column.resizable === false) return;
+
+    const currentWidth = getColumnWidth(column);
+    const step = event.shiftKey ? COLUMN_RESIZE_LARGE_STEP : COLUMN_RESIZE_STEP;
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      resizeColumn(column, currentWidth - step);
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      resizeColumn(column, currentWidth + step);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      resizeColumn(column, column.minWidth ?? MIN_COLUMN_WIDTH);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      resizeColumn(column, column.maxWidth ?? MAX_COLUMN_WIDTH);
+    }
   };
 
   return (
@@ -214,6 +244,9 @@ export function DataGrid<Row extends Record<string, unknown>>({
                 const sortDirection = sorted ? currentSortState?.direction : undefined;
                 const sortLabel = column.label?.toString() ?? column.key;
                 const canResize = resizableColumns && column.resizable !== false;
+                const resizeWidth = getColumnWidth(column);
+                const resizeMinWidth = column.minWidth ?? MIN_COLUMN_WIDTH;
+                const resizeMaxWidth = column.maxWidth ?? MAX_COLUMN_WIDTH;
                 return (
                   <th key={column.key} scope="col" role="columnheader" data-align={column.align} data-resizable={canResize ? "true" : undefined} style={getColumnStyle(column)} aria-sort={sortDirection}>
                     <span className="ds-DataGrid-columnHeader">
@@ -226,7 +259,15 @@ export function DataGrid<Row extends Record<string, unknown>>({
                         <button
                           className="ds-DataGrid-resizeHandle"
                           type="button"
+                          role="separator"
                           aria-label={`${sortLabel} 열 너비 조절 / Resize ${sortLabel} column`}
+                          aria-orientation="vertical"
+                          aria-valuemin={resizeMinWidth}
+                          aria-valuemax={resizeMaxWidth}
+                          aria-valuenow={resizeWidth}
+                          aria-valuetext={`${resizeWidth}px`}
+                          title="방향키: 16px, Shift+방향키: 48px / ArrowLeft/ArrowRight: 16px, Shift+Arrow: 48px"
+                          onKeyDown={(event) => onColumnResizeKeyDown(event, column)}
                           onPointerDown={(event) => startColumnResize(event, column)}
                         />
                       ) : null}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1439,7 +1439,7 @@
 }
 
 .ds-DataGrid-resizeHandle {
-  inline-size: var(--ds-space-2);
+  inline-size: var(--ds-space-3);
   align-self: stretch;
   min-block-size: var(--ds-space-5);
   flex: 0 0 auto;
@@ -1452,6 +1452,8 @@
 .ds-DataGrid-resizeHandle:hover,
 .ds-DataGrid-resizeHandle:focus-visible {
   border-inline-end-color: var(--ds-color-action-primary-bg);
+  outline: var(--ds-focus-ring);
+  outline-offset: var(--ds-size-1);
 }
 
 .ds-DataGrid-row[data-active="true"] {

--- a/scripts/interaction-a11y.mjs
+++ b/scripts/interaction-a11y.mjs
@@ -416,6 +416,48 @@ await check("DataGrid row keyboard navigation", async () => {
   });
 });
 
+await check("DataGrid column resize keyboard controls", async () => {
+  const resizedWidths = [];
+  render(React.createElement(DataGrid, {
+    columns: [
+      { key: "name", label: "이름 / Name", width: "160px", minWidth: 120, maxWidth: 220 },
+      { key: "status", label: "상태 / Status", width: "160px" }
+    ],
+    rows: [
+      { id: "ready", name: "준비 / Ready", status: "완료 / Done" }
+    ],
+    rowKey: (row) => row.id,
+    onColumnResize: (key, width) => {
+      resizedWidths.push(`${key}:${width}`);
+    }
+  }));
+
+  const resizeHandle = screen.getByRole("separator", { name: "이름 / Name 열 너비 조절 / Resize 이름 / Name column" });
+  resizeHandle.focus();
+  fireEvent.keyDown(resizeHandle, { key: "ArrowRight" });
+
+  await waitFor(() => {
+    if (document.activeElement !== resizeHandle) throw new Error("Expected resize handle to remain focused.");
+    if (resizeHandle.getAttribute("aria-valuenow") !== "176") throw new Error(`Expected width 176, received: ${resizeHandle.getAttribute("aria-valuenow")}`);
+    if (!resizedWidths.includes("name:176")) throw new Error("Expected ArrowRight resize callback.");
+  });
+
+  fireEvent.keyDown(resizeHandle, { key: "ArrowLeft", shiftKey: true });
+  await waitFor(() => {
+    if (resizeHandle.getAttribute("aria-valuenow") !== "128") throw new Error(`Expected width 128, received: ${resizeHandle.getAttribute("aria-valuenow")}`);
+  });
+
+  fireEvent.keyDown(resizeHandle, { key: "Home" });
+  await waitFor(() => {
+    if (resizeHandle.getAttribute("aria-valuenow") !== "120") throw new Error(`Expected minimum width 120, received: ${resizeHandle.getAttribute("aria-valuenow")}`);
+  });
+
+  fireEvent.keyDown(resizeHandle, { key: "End" });
+  await waitFor(() => {
+    if (resizeHandle.getAttribute("aria-valuenow") !== "220") throw new Error(`Expected maximum width 220, received: ${resizeHandle.getAttribute("aria-valuenow")}`);
+  });
+});
+
 if (failures.length > 0) {
   console.error(failures.join("\n\n"));
   process.exit(1);


### PR DESCRIPTION
## 변경 사항 / Changes
- DataGrid column resize handle을 keyboard focus 가능한 `role="separator"` control로 보강했습니다. / Hardened the DataGrid column resize handle as a keyboard-focusable `role="separator"` control.
- `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, `aria-valuetext`를 추가했습니다. / Added `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-valuetext`.
- `ArrowLeft`/`ArrowRight`는 16px, `Shift+Arrow`는 48px, `Home`/`End`는 최소/최대 너비로 조절합니다. / `ArrowLeft`/`ArrowRight` adjust by 16px, `Shift+Arrow` by 48px, and `Home`/`End` move to min/max width.
- interaction 접근성 테스트에 keyboard resize path를 추가했습니다. / Added the keyboard resize path to interaction accessibility tests.
- DataGrid README와 changelog를 갱신했습니다. / Updated the DataGrid README and changelog.

## 검증 / Verification
- `npm run build && npx tsx scripts/interaction-a11y.mjs`
- `npm run test`
- `npm run typecheck`
- `npm run test:consumer`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

Closes #18
