### PR TITLE
[codex] Add theme token regression checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: 소비자 fixture 빌드 / Build consumer fixture
         run: npm run test:consumer
 
+      - name: 테마 토큰 회귀 검증 / Theme token regression
+        run: npm run test:tokens
+
       - name: Playwright 브라우저 설치 / Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes are documented in this file.
 - 상호작용 접근성 검증 범위를 Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, SideNav로 확장했습니다. / Expanded interaction accessibility validation to Select, DatePicker, FileUploader, Tabs, Stepper, NavigationRail, and SideNav.
 - 외부 소비자 fixture 앱과 `test:consumer` 검증을 추가했습니다. / Added an external consumer fixture app and `test:consumer` validation.
 - DataGrid column resize keyboard 조작과 ARIA value 상태를 추가했습니다. / Added DataGrid column resize keyboard controls and ARIA value state.
+- theme/token 회귀 검증 스크립트 `test:tokens`를 추가했습니다. / Added the `test:tokens` theme/token regression script.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ npm run test:consumer
 Builds the consumer fixture app against built `@workspace/ui` package exports without source aliases.
 
 ```bash
+npm run test:tokens
+```
+
+token contract의 필수 semantic token, NORMAL/DARK theme 차이, UI CSS raw value/theme selector 회귀를 확인합니다.
+Checks required semantic tokens from the token contract, NORMAL/DARK theme differences, and UI CSS raw value/theme selector regressions.
+
+```bash
 npm run test:visual
 ```
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -12,6 +12,7 @@ npm run typecheck
 npm run build
 npm --workspace @workspace/docs run build
 npm run test:consumer
+npm run test:tokens
 npm run test:visual
 npm pack --workspace @workspace/ui --dry-run
 ```
@@ -24,6 +25,7 @@ npm pack --workspace @workspace/ui --dry-run
 - `test:a11y`는 핵심 accessible markup을 server render 기준으로 확인해야 합니다. / `test:a11y` must verify core accessible markup through server rendering.
 - `test:interaction`은 keyboard, focus return, highlighted option 같은 상호작용 접근성 흐름을 확인해야 합니다. / `test:interaction` must verify interaction accessibility flows such as keyboard, focus return, and highlighted options.
 - `test:consumer`는 source alias 없이 `@workspace/ui` root export, per-component export, `styles.css`, token CSS import를 fixture 앱에서 확인해야 합니다. / `test:consumer` must verify `@workspace/ui` root exports, per-component exports, `styles.css`, and token CSS imports in the fixture app without source aliases.
+- `test:tokens`는 token contract의 필수 semantic token과 NORMAL/DARK theme 차이를 확인해야 합니다. / `test:tokens` must verify required semantic tokens from the token contract and NORMAL/DARK theme differences.
 - `test:visual`은 docs app home, theme compare, DataGrid screenshot과 horizontal overflow를 확인해야 합니다. / `test:visual` must verify docs app home, theme compare, DataGrid screenshots, and horizontal overflow.
 - `test:exports`는 root export와 per-component export가 실제 `dist` 파일과 맞는지 확인해야 합니다. / `test:exports` must verify that root and per-component exports match real `dist` files.
 - React는 dependency가 아니라 peer dependency로 유지합니다. / React must remain a peer dependency, not a bundled dependency.

--- a/docs/theme-system.md
+++ b/docs/theme-system.md
@@ -107,6 +107,7 @@ Run the commands below after changing themes.
 
 ```bash
 npm run components:validate
+npm run test:tokens
 npm run typecheck
 npm run build
 npm --workspace @workspace/docs run build
@@ -114,3 +115,6 @@ npm --workspace @workspace/docs run build
 
 문서 앱의 `테마 시스템 / Theme System` 섹션에서 `NORMAL`, `OCEAN`, `FOREST`, `DARK`를 전환해 컴포넌트가 같은 색상 체계로 함께 바뀌는지 확인합니다.
 In the docs app, switch between `NORMAL`, `OCEAN`, `FOREST`, and `DARK` in the `Theme System` section and confirm components change together through one color system.
+
+`npm run test:tokens`는 token contract의 필수 semantic token 목록, NORMAL/DARK resolved value 차이, UI CSS의 theme-name selector/raw value 회귀를 자동 확인합니다.
+`npm run test:tokens` automatically checks the required semantic token list from the token contract, NORMAL/DARK resolved value differences, and UI CSS theme-name selector/raw value regressions.

--- a/docs/token-contract.md
+++ b/docs/token-contract.md
@@ -30,6 +30,59 @@ Semantic tokens express product intent. Component CSS should prefer semantic tok
 --ds-color-feedback-danger-bg
 ```
 
+## 필수 의미 토큰 / Required Semantic Tokens
+
+`npm run test:tokens`는 아래 목록을 token contract 기준으로 읽어 `:root`, `normal`, `dark` theme set에 누락이 없는지 확인합니다.
+`npm run test:tokens` reads the list below as the token contract and verifies that `:root`, `normal`, and `dark` theme sets do not miss required tokens.
+
+```text
+--ds-color-bg-canvas
+--ds-color-bg-surface
+--ds-color-bg-elevated
+--ds-color-bg-muted
+--ds-color-bg-inverse
+--ds-color-text-primary
+--ds-color-text-secondary
+--ds-color-text-muted
+--ds-color-text-inverse
+--ds-color-border-subtle
+--ds-color-border-default
+--ds-color-border-strong
+--ds-color-action-primary-bg
+--ds-color-action-primary-bg-hover
+--ds-color-action-primary-bg-active
+--ds-color-action-primary-border
+--ds-color-action-primary-fg
+--ds-color-action-neutral-bg
+--ds-color-action-neutral-bg-hover
+--ds-color-action-neutral-bg-active
+--ds-color-action-neutral-border
+--ds-color-action-neutral-fg
+--ds-color-feedback-info-bg
+--ds-color-feedback-info-border
+--ds-color-feedback-info-text
+--ds-color-feedback-success-bg
+--ds-color-feedback-success-border
+--ds-color-feedback-success-text
+--ds-color-feedback-success
+--ds-color-feedback-warning-bg
+--ds-color-feedback-warning-border
+--ds-color-feedback-warning-text
+--ds-color-feedback-warning
+--ds-color-feedback-danger-bg
+--ds-color-feedback-danger-border
+--ds-color-feedback-danger-text
+--ds-color-feedback-danger
+--ds-state-hover-bg
+--ds-state-hover-border
+--ds-state-active-bg
+--ds-state-selected-bg
+--ds-state-selected-border
+--ds-color-overlay-backdrop
+--ds-color-focus-ring
+--ds-focus-ring
+```
+
 ### 테마 토큰 / Theme Tokens
 
 테마는 `normal`을 기본값으로 두고 semantic token override block으로 구성합니다.
@@ -134,3 +187,6 @@ Follow [Theme System](./theme-system.md) for detailed usage.
 
 `npm run components:validate`는 UI CSS의 raw color 사용, 필수 토큰 누락, public class naming, event prop naming을 검사합니다.
 `npm run components:validate` checks raw color usage in UI CSS, required token presence, public class naming, and event prop naming.
+
+`npm run test:tokens`는 이 문서의 필수 의미 토큰 목록을 기준으로 `:root`, `normal`, `dark` theme set 누락과 NORMAL/DARK resolved value 차이를 검사합니다.
+`npm run test:tokens` uses this document's required semantic token list to check `:root`, `normal`, and `dark` theme set coverage and NORMAL/DARK resolved value differences.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:interaction": "npm run build && tsx scripts/interaction-a11y.mjs",
     "test:exports": "npm run build && tsx scripts/verify-package-exports.mjs",
     "test:consumer": "npm run build && npm --workspace @workspace/consumer-fixture run build",
+    "test:tokens": "node scripts/verify-theme-tokens.mjs",
     "test:visual": "node scripts/visual-regression.mjs",
     "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck && npm --workspace @workspace/consumer-fixture run typecheck"
   },

--- a/scripts/verify-theme-tokens.mjs
+++ b/scripts/verify-theme-tokens.mjs
@@ -1,0 +1,110 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const tokenContractPath = join(rootDir, "docs", "token-contract.md");
+const tokensCssPath = join(rootDir, "packages", "tokens", "src", "tokens.css");
+const uiCssPath = join(rootDir, "packages", "ui", "src", "styles.css");
+const failures = [];
+
+const tokenContract = await readFile(tokenContractPath, "utf8");
+const tokensCss = await readFile(tokensCssPath, "utf8");
+const uiCss = await readFile(uiCssPath, "utf8");
+
+function getRequiredSemanticTokens() {
+  const match = tokenContract.match(/## 필수 의미 토큰 \/ Required Semantic Tokens[\s\S]*?```text\n([\s\S]*?)```/);
+  if (!match) {
+    failures.push("필수 의미 토큰 목록을 token contract에서 찾지 못했습니다. / Required semantic token list was not found in the token contract.");
+    return [];
+  }
+  return match[1].split("\n").map((line) => line.trim()).filter((line) => line.startsWith("--ds-"));
+}
+
+function parseBlocks(css) {
+  const blocks = [];
+  const blockPattern = /([^{}]+)\{([^{}]*)\}/g;
+  let match;
+  while ((match = blockPattern.exec(css))) {
+    const declarations = {};
+    for (const declaration of match[2].split(";")) {
+      const declarationMatch = declaration.match(/(--ds-[\w-]+)\s*:\s*(.+)$/);
+      if (declarationMatch) declarations[declarationMatch[1]] = declarationMatch[2].trim();
+    }
+    blocks.push({ selector: match[1].trim(), declarations });
+  }
+  return blocks;
+}
+
+function findBlock(blocks, selectorText) {
+  return blocks.find((block) => block.selector.includes(selectorText))?.declarations ?? {};
+}
+
+function resolveTokenValue(tokenName, tokenMap, seen = new Set()) {
+  const value = tokenMap[tokenName];
+  if (!value || seen.has(tokenName)) return value;
+  seen.add(tokenName);
+  return value.replace(/var\((--ds-[\w-]+)\)/g, (_, nestedToken) => resolveTokenValue(nestedToken, tokenMap, seen) ?? `var(${nestedToken})`);
+}
+
+const requiredSemanticTokens = getRequiredSemanticTokens();
+const tokenBlocks = parseBlocks(tokensCss);
+const rootTokens = findBlock(tokenBlocks, ":root");
+const normalTokens = findBlock(tokenBlocks, '[data-ds-theme="normal"]');
+const darkTokens = findBlock(tokenBlocks, '[data-ds-theme="dark"]');
+const normalTokenMap = { ...rootTokens, ...normalTokens };
+const darkTokenMap = { ...rootTokens, ...darkTokens };
+
+for (const tokenName of requiredSemanticTokens) {
+  if (!rootTokens[tokenName]) failures.push(`${tokenName}가 :root에 없습니다. / ${tokenName} is missing from :root.`);
+  if (!normalTokens[tokenName]) failures.push(`${tokenName}가 normal theme에 없습니다. / ${tokenName} is missing from the normal theme.`);
+  if (!darkTokens[tokenName]) failures.push(`${tokenName}가 dark theme에 없습니다. / ${tokenName} is missing from the dark theme.`);
+}
+
+const mustDifferBetweenNormalAndDark = [
+  "--ds-color-bg-surface",
+  "--ds-color-text-primary",
+  "--ds-color-border-default",
+  "--ds-color-action-primary-bg",
+  "--ds-state-selected-bg",
+  "--ds-color-focus-ring"
+];
+
+for (const tokenName of mustDifferBetweenNormalAndDark) {
+  const normalValue = resolveTokenValue(tokenName, normalTokenMap);
+  const darkValue = resolveTokenValue(tokenName, darkTokenMap);
+  if (normalValue === darkValue) {
+    failures.push(`${tokenName}의 normal/dark 값이 같습니다. / ${tokenName} resolves to the same value in normal and dark themes.`);
+  }
+}
+
+const componentTokenPrefixes = ["--ds-field-", "--ds-card-", "--ds-overlay-", "--ds-list-", "--ds-table-"];
+const semanticComponentTokenPattern = /-(bg|border|fg|radius|shadow|color)(-|$)/;
+for (const [tokenName, value] of Object.entries(rootTokens)) {
+  if (!componentTokenPrefixes.some((prefix) => tokenName.startsWith(prefix))) continue;
+  if (!semanticComponentTokenPattern.test(tokenName)) continue;
+  if (!/var\(--ds-(color|state|radius|shadow)-/.test(value)) {
+    failures.push(`${tokenName}는 semantic token을 바라봐야 합니다. / ${tokenName} should resolve through semantic tokens.`);
+  }
+}
+
+if (/\[data-ds-theme=|\.ds-theme-/.test(uiCss)) {
+  failures.push("UI CSS에서 theme name selector를 직접 사용했습니다. / UI CSS directly uses a theme-name selector.");
+}
+
+const rawColorPattern = /#[0-9a-fA-F]{3,8}\b|rgba?\(|hsla?\(/;
+for (const [index, line] of uiCss.split("\n").entries()) {
+  if (rawColorPattern.test(line)) {
+    failures.push(`UI CSS ${index + 1}행에 raw color가 있습니다. / UI CSS line ${index + 1} contains a raw color.`);
+  }
+  if (!line.trim().startsWith("@") && /:\s*[^;]*\b\d*\.?\d+(px|rem|em)\b/.test(line)) {
+    failures.push(`UI CSS ${index + 1}행에 raw size 값이 있습니다. / UI CSS line ${index + 1} contains a raw size value.`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+
+console.log(`theme/token 회귀 검증 완료: ${requiredSemanticTokens.length}개 필수 semantic token. / Theme/token regression verified: ${requiredSemanticTokens.length} required semantic tokens.`);


### PR DESCRIPTION
## 변경 사항 / Changes
- token contract의 필수 semantic token 목록을 문서화하고 `test:tokens`가 이를 읽어 검증하도록 추가했습니다. / Documented the required semantic token list in the token contract and added `test:tokens` to validate against it.
- `:root`, `normal`, `dark` theme set의 필수 token 누락을 검사합니다. / Checks required token coverage across `:root`, `normal`, and `dark` theme sets.
- NORMAL/DARK resolved value가 핵심 semantic token에서 실제로 달라지는지 확인합니다. / Verifies that NORMAL/DARK resolved values differ for key semantic tokens.
- UI CSS에서 theme-name selector, raw color, raw size declaration 회귀를 검사합니다. / Checks UI CSS regressions for theme-name selectors, raw colors, and raw size declarations.
- CI, README, release checklist, theme/token 문서를 갱신했습니다. / Updated CI, README, release checklist, and theme/token docs.

## 검증 / Verification
- `npm run test:tokens`
- `npm run test`
- `npm run typecheck`
- `npm run test:consumer`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

Closes #20
