### PR TITLE
[codex] Add public prop type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: 테마 토큰 회귀 검증 / Theme token regression
         run: npm run test:tokens
 
+      - name: Public prop 타입 검증 / Public prop type checks
+        run: npm run test:types
+
       - name: Playwright 브라우저 설치 / Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes are documented in this file.
 - 외부 소비자 fixture 앱과 `test:consumer` 검증을 추가했습니다. / Added an external consumer fixture app and `test:consumer` validation.
 - DataGrid column resize keyboard 조작과 ARIA value 상태를 추가했습니다. / Added DataGrid column resize keyboard controls and ARIA value state.
 - theme/token 회귀 검증 스크립트 `test:tokens`를 추가했습니다. / Added the `test:tokens` theme/token regression script.
+- public prop API 타입 회귀 검증 스크립트 `test:types`를 추가했습니다. / Added the `test:types` public prop API type regression script.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ token contract의 필수 semantic token, NORMAL/DARK theme 차이, UI CSS raw va
 Checks required semantic tokens from the token contract, NORMAL/DARK theme differences, and UI CSS raw value/theme selector regressions.
 
 ```bash
+npm run test:types
+```
+
+소비자가 사용하는 public prop API의 허용/비허용 TypeScript 예제를 확인합니다.
+Checks allowed and disallowed TypeScript examples for public prop APIs used by consumers.
+
+```bash
 npm run test:visual
 ```
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -13,6 +13,7 @@ npm run build
 npm --workspace @workspace/docs run build
 npm run test:consumer
 npm run test:tokens
+npm run test:types
 npm run test:visual
 npm pack --workspace @workspace/ui --dry-run
 ```
@@ -26,6 +27,7 @@ npm pack --workspace @workspace/ui --dry-run
 - `test:interaction`은 keyboard, focus return, highlighted option 같은 상호작용 접근성 흐름을 확인해야 합니다. / `test:interaction` must verify interaction accessibility flows such as keyboard, focus return, and highlighted options.
 - `test:consumer`는 source alias 없이 `@workspace/ui` root export, per-component export, `styles.css`, token CSS import를 fixture 앱에서 확인해야 합니다. / `test:consumer` must verify `@workspace/ui` root exports, per-component exports, `styles.css`, and token CSS imports in the fixture app without source aliases.
 - `test:tokens`는 token contract의 필수 semantic token과 NORMAL/DARK theme 차이를 확인해야 합니다. / `test:tokens` must verify required semantic tokens from the token contract and NORMAL/DARK theme differences.
+- `test:types`는 public prop API의 허용/비허용 TypeScript 예제를 확인해야 합니다. / `test:types` must verify allowed and disallowed TypeScript examples for public prop APIs.
 - `test:visual`은 docs app home, theme compare, DataGrid screenshot과 horizontal overflow를 확인해야 합니다. / `test:visual` must verify docs app home, theme compare, DataGrid screenshots, and horizontal overflow.
 - `test:exports`는 root export와 per-component export가 실제 `dist` 파일과 맞는지 확인해야 합니다. / `test:exports` must verify that root and per-component exports match real `dist` files.
 - React는 dependency가 아니라 peer dependency로 유지합니다. / React must remain a peer dependency, not a bundled dependency.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:interaction": "npm run build && tsx scripts/interaction-a11y.mjs",
     "test:exports": "npm run build && tsx scripts/verify-package-exports.mjs",
     "test:consumer": "npm run build && npm --workspace @workspace/consumer-fixture run build",
+    "test:types": "npm run build && tsc -p tests/public-api/tsconfig.json --noEmit",
     "test:tokens": "node scripts/verify-theme-tokens.mjs",
     "test:visual": "node scripts/visual-regression.mjs",
     "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck && npm --workspace @workspace/consumer-fixture run typecheck"

--- a/tests/public-api/public-props.test.tsx
+++ b/tests/public-api/public-props.test.tsx
@@ -1,0 +1,162 @@
+import { createRef, type ReactNode } from "react";
+import {
+  Button,
+  Combobox,
+  DataGrid,
+  Dialog,
+  Field,
+  type ButtonProps,
+  type ComboboxOption,
+  type DataGridColumn,
+  type DataGridProps,
+  type DialogProps,
+  type FieldProps
+} from "@workspace/ui";
+import { Button as ButtonEntry, type ButtonProps as ButtonEntryProps } from "@workspace/ui/components/actions/button";
+import { DataGrid as DataGridEntry, type DataGridProps as DataGridEntryProps } from "@workspace/ui/components/data-display/data-grid";
+
+type TaskRow = {
+  id: string;
+  task: string;
+  state: "ready" | "blocked";
+  count: number;
+};
+
+const taskRows: TaskRow[] = [
+  { id: "api", task: "API", state: "ready", count: 2 }
+];
+
+const taskColumns: Array<DataGridColumn<TaskRow>> = [
+  { key: "task", label: "작업 / Task", sortable: true, resizable: true, minWidth: 120 },
+  { key: "state", label: "상태 / State", align: "center", renderCell: (row) => row.state },
+  { key: "count", label: "개수 / Count", align: "end", renderCell: (row) => row.count }
+];
+
+const buttonProps: ButtonProps = {
+  variant: "outline",
+  tone: "danger",
+  size: "lg",
+  fullWidth: true,
+  selected: true,
+  justify: "between",
+  iconStart: "!",
+  onClick: (event) => {
+    event.currentTarget.focus();
+  },
+  children: "삭제 / Delete"
+};
+
+const buttonElement = <Button {...buttonProps} />;
+const buttonEntryProps: ButtonEntryProps = { tone: "neutral", variant: "ghost", children: "취소 / Cancel" };
+const buttonEntryElement = <ButtonEntry {...buttonEntryProps} />;
+
+const fieldProps: FieldProps = {
+  label: "이름 / Name",
+  controlId: "name",
+  description: "설명 / Description",
+  error: null,
+  required: true,
+  orientation: "horizontal",
+  width: "full",
+  hideLabel: false,
+  children: <input id="name" />
+};
+
+const fieldElement = <Field {...fieldProps} />;
+
+const comboboxOptions: ComboboxOption[] = [
+  { label: "디자인 / Design", value: "design", keywords: ["product"] },
+  { label: "개발 / Engineering", value: "engineering", disabled: true }
+];
+
+const comboboxElement = (
+  <Combobox
+    label="팀 / Team"
+    value="design"
+    options={comboboxOptions}
+    width="full"
+    onValueChange={(value) => {
+      value.toUpperCase();
+    }}
+  />
+);
+
+const dialogInitialFocus = createRef<HTMLButtonElement>();
+const dialogProps: DialogProps = {
+  triggerLabel: "열기 / Open",
+  title: "확인 / Confirm",
+  description: "변경합니다. / Applies changes.",
+  defaultOpen: false,
+  modal: true,
+  closeOnBackdropClick: false,
+  initialFocus: dialogInitialFocus,
+  actions: [{ label: "저장 / Save", tone: "brand" }],
+  children: <button ref={dialogInitialFocus}>첫 항목 / First item</button>
+};
+
+const dialogElement = <Dialog {...dialogProps} />;
+
+const dataGridProps: DataGridProps<TaskRow> = {
+  caption: "작업 / Tasks",
+  columns: taskColumns,
+  rows: taskRows,
+  rowKey: (row) => row.id,
+  sortState: { key: "task", direction: "ascending" },
+  selectedRowKeys: ["api"],
+  activeRowKey: "api",
+  keyboardNavigation: "row",
+  resizableColumns: true,
+  rowActions: (row): ReactNode => <button>{row.task}</button>,
+  onSortChange: (sortState) => {
+    sortState?.key.toUpperCase();
+  },
+  onSelectedRowKeysChange: (keys) => {
+    keys.join(",");
+  },
+  onActiveRowKeyChange: (key, row) => {
+    key?.toUpperCase();
+    row?.task.toUpperCase();
+  },
+  onColumnResize: (key, width) => {
+    key.toUpperCase();
+    width.toFixed();
+  }
+};
+
+const dataGridElement = <DataGrid {...dataGridProps} />;
+const dataGridEntryProps: DataGridEntryProps<TaskRow> = dataGridProps;
+const dataGridEntryElement = <DataGridEntry {...dataGridEntryProps} />;
+
+// @ts-expect-error Button tone은 정해진 tone만 허용합니다. / Button tone only allows defined tones.
+const invalidButtonTone = <Button tone="critical">삭제 / Delete</Button>;
+
+// @ts-expect-error Field children은 필수입니다. / Field children are required.
+const invalidFieldMissingChildren = <Field label="이름 / Name" />;
+
+// @ts-expect-error Combobox value는 string이어야 합니다. / Combobox value must be a string.
+const invalidComboboxValue = <Combobox value={1} options={comboboxOptions} />;
+
+// @ts-expect-error Dialog size는 sm, md, lg만 허용합니다. / Dialog size only allows sm, md, or lg.
+const invalidDialogSize = <Dialog size="xl" />;
+
+// @ts-expect-error DataGrid column key는 row key에 포함되어야 합니다. / DataGrid column key must be part of the row keys.
+const invalidDataGridColumn: DataGridColumn<TaskRow> = { key: "missing", label: "누락 / Missing" };
+
+// @ts-expect-error DataGrid sort key는 row key에 포함되어야 합니다. / DataGrid sort key must be part of the row keys.
+const invalidDataGridSort = <DataGrid<TaskRow> columns={taskColumns} rows={taskRows} sortState={{ key: "missing", direction: "ascending" }} />;
+
+void [
+  buttonElement,
+  buttonEntryElement,
+  fieldElement,
+  comboboxElement,
+  dialogElement,
+  dataGridElement,
+  dataGridEntryElement,
+  invalidButtonTone,
+  invalidFieldMissingChildren,
+  invalidComboboxValue,
+  invalidDialogSize,
+  invalidDataGridColumn,
+  invalidDataGridSort
+];

--- a/tests/public-api/tsconfig.json
+++ b/tests/public-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["./public-props.test.tsx"]
+}


### PR DESCRIPTION
## 변경 사항 / Changes
- TypeScript fixture 기반 public prop API 회귀 테스트를 추가했습니다. / Added TypeScript-fixture-based public prop API regression tests.
- Button, Field, Combobox, Dialog, DataGrid의 허용/비허용 prop 예제를 고정했습니다. / Locked allowed and disallowed prop examples for Button, Field, Combobox, Dialog, and DataGrid.
- root export와 per-component export 타입을 함께 확인합니다. / Verifies both root export and per-component export types.
- `npm run test:types` script와 CI step, README, release checklist를 추가했습니다. / Added the `npm run test:types` script, CI step, README, and release checklist entries.

## 검증 / Verification
- `npm run test:types`
- `npm run test`
- `npm run typecheck`
- `npm run test:tokens`
- `npm run test:consumer`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

Closes #22
