### PR TITLE
[codex] Add release automation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release / 배포
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run 또는 publish / dry-run or publish"
+        required: true
+        default: "dry-run"
+        type: choice
+        options:
+          - dry-run
+          - publish
+      confirm:
+        description: "publish 실행 시 'publish @workspace/ui' 입력 / Enter 'publish @workspace/ui' to publish"
+        required: false
+        default: ""
+
+jobs:
+  release:
+    name: 릴리즈 / Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: npm-release
+
+    steps:
+      - name: 체크아웃 / Checkout
+        uses: actions/checkout@v4
+
+      - name: Node 설정 / Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: 의존성 설치 / Install dependencies
+        run: npm ci
+
+      - name: Playwright 브라우저 설치 / Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: 릴리즈 dry-run / Release dry-run
+        run: npm run release:dry-run
+
+      - name: publish 확인 / Confirm publish
+        if: inputs.mode == 'publish' && inputs.confirm != 'publish @workspace/ui'
+        run: |
+          echo "publish confirm 값이 올바르지 않습니다. / Publish confirm value is not correct."
+          exit 1
+
+      - name: npm publish / npm publish
+        if: inputs.mode == 'publish'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --workspace @workspace/ui --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes are documented in this file.
 - DataGrid column resize keyboard 조작과 ARIA value 상태를 추가했습니다. / Added DataGrid column resize keyboard controls and ARIA value state.
 - theme/token 회귀 검증 스크립트 `test:tokens`를 추가했습니다. / Added the `test:tokens` theme/token regression script.
 - public prop API 타입 회귀 검증 스크립트 `test:types`를 추가했습니다. / Added the `test:types` public prop API type regression script.
+- release prepare, dry-run, publish workflow 자동화를 추가했습니다. / Added release prepare, dry-run, and publish workflow automation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ npm run test:types
 Checks allowed and disallowed TypeScript examples for public prop APIs used by consumers.
 
 ```bash
+npm run release:dry-run
+```
+
+릴리즈 전 전체 검증, release metadata 확인, `npm pack --dry-run`을 한 번에 실행합니다.
+Runs full release validation, release metadata checks, and `npm pack --dry-run` together.
+
+```bash
 npm run test:visual
 ```
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -15,6 +15,7 @@ npm run test:consumer
 npm run test:tokens
 npm run test:types
 npm run test:visual
+npm run release:verify
 npm pack --workspace @workspace/ui --dry-run
 ```
 
@@ -30,6 +31,7 @@ npm pack --workspace @workspace/ui --dry-run
 - `test:types`는 public prop API의 허용/비허용 TypeScript 예제를 확인해야 합니다. / `test:types` must verify allowed and disallowed TypeScript examples for public prop APIs.
 - `test:visual`은 docs app home, theme compare, DataGrid screenshot과 horizontal overflow를 확인해야 합니다. / `test:visual` must verify docs app home, theme compare, DataGrid screenshots, and horizontal overflow.
 - `test:exports`는 root export와 per-component export가 실제 `dist` 파일과 맞는지 확인해야 합니다. / `test:exports` must verify that root and per-component exports match real `dist` files.
+- `release:verify`는 release script, dist 산출물, peer dependency, changelog 상태를 확인해야 합니다. / `release:verify` must verify release scripts, dist output, peer dependencies, and changelog status.
 - React는 dependency가 아니라 peer dependency로 유지합니다. / React must remain a peer dependency, not a bundled dependency.
 
 ## 산출물 확인 / Output Check
@@ -60,3 +62,10 @@ Verify `packages/ui/package.json` export paths against real output with `npm run
 
 이 레포는 현재 workspace 기반 베이스입니다. 실제 npm 또는 GitHub Packages 배포는 [릴리즈 정책](./release-policy.md)을 기준으로 별도 위험 변경 PR에서 결정합니다.
 This repo is currently a workspace-based foundation. Publishing to npm or GitHub Packages should be decided in a separate risky-change PR using [Release Policy](./release-policy.md).
+
+## 실제 publish 전 확인 / Before Real Publish
+
+- `npm-release` environment reviewer를 지정합니다. / Configure reviewers for the `npm-release` environment.
+- `NPM_TOKEN` secret은 automation 권한만 가진 npm automation token으로 등록합니다. / Register `NPM_TOKEN` as an npm automation token with only the required publish permission.
+- `mode=publish` 실행 전 package name과 `private` flag가 npm public publish 기준과 맞는지 확인합니다. / Before running `mode=publish`, confirm that the package name and `private` flag match npm public publish requirements.
+- `confirm`에는 `publish @workspace/ui`를 정확히 입력합니다. / Enter exactly `publish @workspace/ui` in `confirm`.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -13,6 +13,7 @@ This policy defines the baseline for operating `@workspace/ui` as a reusable Rea
 
 - 공개 OSS 또는 외부 프로젝트 소비가 목표라면 npm public registry를 기본값으로 둡니다. / Use the npm public registry by default for OSS or external project consumption.
 - 사내/비공개 소비가 목표라면 GitHub Packages를 사용하되 `.npmrc`와 token 운영 문서를 별도 PR로 추가합니다. / Use GitHub Packages for internal/private consumption, adding `.npmrc` and token operation docs in a separate PR.
+- 현재 자동화의 registry 대상은 npm public입니다. 실제 publish 전에는 package name을 조직 scope로 바꾸고 `private` flag를 해제하는 별도 위험 변경 PR이 필요합니다. / The current automation targets the npm public registry. Before real publishing, a separate risky-change PR must change the package name to an organization scope and remove the `private` flag.
 
 ## 버전 정책 / Versioning Policy
 
@@ -26,15 +27,41 @@ This policy defines the baseline for operating `@workspace/ui` as a reusable Rea
 - 항목은 Added, Changed, Fixed, Docs로 묶습니다. / Group entries under Added, Changed, Fixed, and Docs.
 - PR description의 verification 결과를 changelog entry와 맞춥니다. / Align PR verification results with the changelog entry.
 
+## 버전 준비 / Version Preparation
+
+릴리즈 버전을 만들 때는 아래 script로 `packages/ui/package.json` version과 `CHANGELOG.md` release heading을 함께 준비합니다.
+When preparing a release version, use the script below to update the `packages/ui/package.json` version and the `CHANGELOG.md` release heading together.
+
+```bash
+npm run release:prepare -- 0.2.0
+npm install --package-lock-only
+```
+
+- `release:prepare`는 `CHANGELOG.md`의 기존 `Unreleased` 내용을 `버전 - 날짜` heading 아래로 이동합니다. / `release:prepare` moves the existing `Unreleased` content under a `version - date` heading.
+- lockfile은 npm workspace metadata를 포함하므로 version 준비 후 `npm install --package-lock-only`로 갱신합니다. / The lockfile contains npm workspace metadata, so update it with `npm install --package-lock-only` after preparing the version.
+
 ## 배포 전 게이트 / Pre-Publish Gate
 
 ```bash
-npm run test
-npm run typecheck
-npm --workspace @workspace/docs run build
-npm pack --workspace @workspace/ui --dry-run
+npm run release:dry-run
 ```
 
 - dry run 산출물에 `dist`, `README.md`, package metadata가 포함되어야 합니다. / The dry-run output must include `dist`, `README.md`, and package metadata.
 - dry run 산출물에 오래된 `dist/src` 같은 중복 build output이 포함되면 build cleanup을 먼저 수정합니다. / If the dry-run output includes stale duplicate build output such as `dist/src`, fix build cleanup first.
 - package export는 `npm run test:exports` 결과와 일치해야 합니다. / Package exports must match the result of `npm run test:exports`.
+
+## Publish Workflow / Publish Workflow
+
+`.github/workflows/release.yml`은 수동 실행만 허용합니다.
+`.github/workflows/release.yml` only allows manual execution.
+
+- `mode=dry-run`은 검증과 `npm pack --dry-run`만 실행합니다. / `mode=dry-run` only runs validation and `npm pack --dry-run`.
+- `mode=publish`는 `confirm` 값이 `publish @workspace/ui`일 때만 `npm publish --workspace @workspace/ui --access public --provenance`를 실행합니다. / `mode=publish` runs `npm publish --workspace @workspace/ui --access public --provenance` only when `confirm` is `publish @workspace/ui`.
+- GitHub environment는 `npm-release`, secret은 `NPM_TOKEN`을 사용합니다. / The GitHub environment is `npm-release`, and the secret is `NPM_TOKEN`.
+- 실제 publish 전에 npm package name, `private` flag, npm organization permission을 확인합니다. / Before real publishing, verify the npm package name, `private` flag, and npm organization permissions.
+
+## Rollback / Rollback
+
+- 잘못된 release는 같은 major/minor에서 patch version을 올려 수정 배포합니다. / Fix an incorrect release by publishing a patch version in the same major/minor line.
+- npm unpublish는 소비자 영향을 만들 수 있으므로 보안 사고나 잘못된 secret 노출 같은 긴급 상황에서만 사용합니다. / Use npm unpublish only for emergencies such as security incidents or leaked secrets because it can affect consumers.
+- rollback PR에는 영향받는 package version, 원인, 수정 commit, 소비자 조치가 포함되어야 합니다. / A rollback PR must include the affected package version, cause, fix commit, and consumer action.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test:types": "npm run build && tsc -p tests/public-api/tsconfig.json --noEmit",
     "test:tokens": "node scripts/verify-theme-tokens.mjs",
     "test:visual": "node scripts/visual-regression.mjs",
+    "release:verify": "node scripts/verify-release.mjs",
+    "release:prepare": "node scripts/prepare-release.mjs",
+    "release:dry-run": "npm run test && npm run typecheck && npm --workspace @workspace/docs run build && npm run test:consumer && npm run test:tokens && npm run test:types && npm run test:visual && npm run release:verify && npm pack --workspace @workspace/ui --dry-run",
     "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck && npm --workspace @workspace/consumer-fixture run typecheck"
   },
   "dependencies": {

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -1,0 +1,32 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const version = process.argv[2];
+
+if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+  console.error("사용법: npm run release:prepare -- 0.2.0 / Usage: npm run release:prepare -- 0.2.0");
+  process.exit(1);
+}
+
+const today = new Date().toISOString().slice(0, 10);
+const uiPackagePath = join(rootDir, "packages", "ui", "package.json");
+const uiPackage = JSON.parse(await readFile(uiPackagePath, "utf8"));
+uiPackage.version = version;
+await writeFile(uiPackagePath, `${JSON.stringify(uiPackage, null, 2)}\n`);
+
+const changelogPath = join(rootDir, "CHANGELOG.md");
+const changelog = await readFile(changelogPath, "utf8");
+if (!changelog.includes("## Unreleased")) {
+  console.error("CHANGELOG.md에 Unreleased 섹션이 없습니다. / CHANGELOG.md is missing the Unreleased section.");
+  process.exit(1);
+}
+
+const nextChangelog = changelog.replace(
+  "## Unreleased",
+  `## Unreleased\n\n### Added\n\n- 다음 릴리즈 변경 사항을 기록합니다. / Record changes for the next release.\n\n## ${version} - ${today}`
+);
+await writeFile(changelogPath, nextChangelog);
+
+console.log(`릴리즈 ${version} 준비 완료. npm install --package-lock-only를 실행해 lockfile을 갱신하세요. / Release ${version} prepared. Run npm install --package-lock-only to update the lockfile.`);

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,0 +1,55 @@
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const failures = [];
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function mustExist(label, path) {
+  try {
+    await access(path);
+  } catch {
+    failures.push(`${label} 파일이 없습니다. / Missing ${label} file: ${path}`);
+  }
+}
+
+const rootPackage = await readJson(join(rootDir, "package.json"));
+const uiPackage = await readJson(join(rootDir, "packages", "ui", "package.json"));
+const changelog = await readFile(join(rootDir, "CHANGELOG.md"), "utf8");
+
+const requiredRootScripts = ["test", "typecheck", "test:consumer", "test:tokens", "test:types", "test:visual", "release:dry-run"];
+for (const scriptName of requiredRootScripts) {
+  if (!rootPackage.scripts?.[scriptName]) {
+    failures.push(`${scriptName} script가 package.json에 없습니다. / ${scriptName} script is missing from package.json.`);
+  }
+}
+
+if (!uiPackage.peerDependencies?.react || !uiPackage.peerDependencies?.["react-dom"]) {
+  failures.push("React peer dependency가 누락되었습니다. / React peer dependencies are missing.");
+}
+
+if (!uiPackage.files?.includes("dist") || !uiPackage.files?.includes("README.md")) {
+  failures.push("packages/ui files 목록에 dist와 README.md가 필요합니다. / packages/ui files must include dist and README.md.");
+}
+
+await mustExist("UI dist index", join(rootDir, "packages", "ui", "dist", "index.js"));
+await mustExist("UI dist types", join(rootDir, "packages", "ui", "dist", "index.d.ts"));
+await mustExist("UI dist styles", join(rootDir, "packages", "ui", "dist", "styles.css"));
+
+const unreleasedMatch = changelog.match(/## Unreleased([\s\S]*?)(?:\n## |\n$)/);
+if (!unreleasedMatch) {
+  failures.push("CHANGELOG.md에 Unreleased 섹션이 없습니다. / CHANGELOG.md is missing the Unreleased section.");
+} else if (!/- .+ \/ .+/.test(unreleasedMatch[1])) {
+  failures.push("CHANGELOG.md Unreleased에 한글/영문 병기 항목이 필요합니다. / CHANGELOG.md Unreleased needs Korean/English paired entries.");
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+
+console.log("릴리즈 메타데이터 검증 완료. / Release metadata checks passed.");


### PR DESCRIPTION
## 변경 사항 / Changes
- 수동 실행 전용 `.github/workflows/release.yml`을 추가했습니다. / Added a manual-only `.github/workflows/release.yml`.
- `mode=dry-run`과 `mode=publish`를 분리하고, publish는 `confirm=publish @workspace/ui` 입력이 있어야만 실행되게 했습니다. / Split `mode=dry-run` and `mode=publish`, and require `confirm=publish @workspace/ui` before publish runs.
- `release:prepare`, `release:verify`, `release:dry-run` scripts를 추가했습니다. / Added `release:prepare`, `release:verify`, and `release:dry-run` scripts.
- npm public registry를 현재 자동화의 기준 registry로 문서화했습니다. / Documented npm public as the target registry for the current automation.
- `NPM_TOKEN`, `npm-release` environment, rollback, version/changelog 준비 절차를 문서화했습니다. / Documented `NPM_TOKEN`, the `npm-release` environment, rollback, and version/changelog preparation.

## 위험 체크리스트 / Risk Checklist
- [x] 영향을 받는 항목: release scripts, GitHub Actions workflow, npm publish path. / Affected areas: release scripts, GitHub Actions workflow, npm publish path.
- [x] 실제 publish는 `workflow_dispatch` + `mode=publish` + confirm string + `NPM_TOKEN`이 있어야 실행됩니다. / Real publish requires `workflow_dispatch`, `mode=publish`, confirm string, and `NPM_TOKEN`.
- [x] 현재 package name/private 상태에서는 실제 npm public publish 전 별도 위험 변경 PR이 필요하다고 문서화했습니다. / Documented that the current package name/private state requires a separate risky-change PR before real npm public publishing.
- [x] rollback은 patch release 우선, npm unpublish는 긴급 상황 한정으로 문서화했습니다. / Documented patch release as the primary rollback path and npm unpublish only for emergencies.

## 검증 / Verification
- `npm run release:dry-run`
- `git diff --check`

Closes #19
