### PR TITLE
[codex] Add lint and format quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: 의존성 설치 / Install dependencies
         run: npm ci
 
+      - name: Lint와 format 검증 / Lint and format checks
+        run: npm run lint
+
       - name: 컴포넌트 검증 / Component validation
         run: npm run test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes are documented in this file.
 - theme/token 회귀 검증 스크립트 `test:tokens`를 추가했습니다. / Added the `test:tokens` theme/token regression script.
 - public prop API 타입 회귀 검증 스크립트 `test:types`를 추가했습니다. / Added the `test:types` public prop API type regression script.
 - release prepare, dry-run, publish workflow 자동화를 추가했습니다. / Added release prepare, dry-run, and publish workflow automation.
+- lint/format 최소 품질 게이트 `npm run lint`를 추가했습니다. / Added the minimal lint/format quality gate `npm run lint`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ npm run components:validate
 Validates catalog component folders, required documents, required exports, token contracts, CSS naming, event prop naming, and the no-raw-color rule for UI CSS.
 
 ```bash
+npm run lint
+```
+
+TypeScript/TSX/MJS, CSS, Markdown, JSON/YAML의 기본 format 회귀를 확인합니다.
+Checks basic format regressions across TypeScript/TSX/MJS, CSS, Markdown, and JSON/YAML.
+
+```bash
 npm run test
 ```
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,0 +1,32 @@
+# 품질 게이트 / Quality Gates
+
+이 문서는 CI에서 실행하는 lint/format 최소 기준을 설명합니다.
+This document explains the minimum lint/format criteria used in CI.
+
+## 현재 범위 / Current Scope
+
+`npm run lint`는 `scripts/verify-quality-gates.mjs`를 실행합니다.
+`npm run lint` runs `scripts/verify-quality-gates.mjs`.
+
+- TypeScript/TSX/MJS/JS: CRLF, trailing whitespace, tab indentation, merge conflict marker, missing final newline을 검사합니다. / TypeScript/TSX/MJS/JS checks CRLF, trailing whitespace, tab indentation, merge conflict markers, and missing final newlines.
+- CSS: CRLF, trailing whitespace, tab indentation, merge conflict marker, missing final newline을 검사합니다. / CSS checks CRLF, trailing whitespace, tab indentation, merge conflict markers, and missing final newlines.
+- Markdown: CRLF, trailing whitespace, merge conflict marker, missing final newline을 검사합니다. / Markdown checks CRLF, trailing whitespace, merge conflict markers, and missing final newlines.
+- JSON/YAML: CRLF, trailing whitespace, tab indentation, merge conflict marker, missing final newline을 검사합니다. / JSON/YAML checks CRLF, trailing whitespace, tab indentation, merge conflict markers, and missing final newlines.
+
+## 실패 메시지 / Failure Messages
+
+실패 메시지는 `파일:줄: 한글 설명 / English explanation` 형식으로 출력됩니다.
+Failure messages are printed as `file:line: Korean explanation / English explanation`.
+
+```bash
+npm run lint
+```
+
+## 단계적 확장 / Phased Expansion
+
+기존 파일 전체 rewrite를 피하기 위해 Prettier/ESLint 전면 도입은 별도 PR에서 처리합니다.
+To avoid rewriting the whole repository at once, full Prettier/ESLint adoption should happen in a separate PR.
+
+- 1단계: 현재 최소 whitespace/conflict marker gate를 유지합니다. / Phase 1: Keep the current minimal whitespace/conflict marker gate.
+- 2단계: import 정렬과 TypeScript lint rule을 추가합니다. / Phase 2: Add import ordering and TypeScript lint rules.
+- 3단계: Markdown formatter 또는 Prettier check를 적용합니다. / Phase 3: Add Markdown formatting or Prettier checks.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -7,6 +7,7 @@ Check the items below before releasing `@workspace/ui` for use in other projects
 
 ```bash
 npm run components:validate
+npm run lint
 npm run test
 npm run typecheck
 npm run build
@@ -20,6 +21,7 @@ npm pack --workspace @workspace/ui --dry-run
 ```
 
 - component folder마다 `{slug}.tsx`, `index.ts`, `README.md`, `spec.md`가 있어야 합니다. / Each component folder must have `{slug}.tsx`, `index.ts`, `README.md`, and `spec.md`.
+- `lint`는 TypeScript/TSX/MJS, CSS, Markdown, JSON/YAML의 기본 format 회귀를 확인해야 합니다. / `lint` must verify basic format regressions across TypeScript/TSX/MJS, CSS, Markdown, and JSON/YAML.
 - `packages/ui/src/index.ts`는 public export만 담당해야 합니다. / `packages/ui/src/index.ts` should only manage public exports.
 - `packages/ui/src/components.tsx` 같은 중앙 구현 파일은 만들지 않습니다. / Do not create central implementation files such as `packages/ui/src/components.tsx`.
 - build는 `packages/ui/dist`를 먼저 정리해 stale output이 tarball에 들어가지 않아야 합니다. / Build must clean `packages/ui/dist` first so stale output does not enter the tarball.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "npm --workspace @workspace/ui run build",
     "dev": "npm --workspace @workspace/docs run dev",
     "docs:dev": "npm --workspace @workspace/docs run dev",
+    "lint": "node scripts/verify-quality-gates.mjs",
     "test": "npm run components:validate && npm run build && tsx scripts/accessibility-smoke.mjs && tsx scripts/interaction-a11y.mjs && tsx scripts/verify-package-exports.mjs",
     "test:a11y": "npm run build && tsx scripts/accessibility-smoke.mjs",
     "test:interaction": "npm run build && tsx scripts/interaction-a11y.mjs",
@@ -23,7 +24,7 @@
     "test:visual": "node scripts/visual-regression.mjs",
     "release:verify": "node scripts/verify-release.mjs",
     "release:prepare": "node scripts/prepare-release.mjs",
-    "release:dry-run": "npm run test && npm run typecheck && npm --workspace @workspace/docs run build && npm run test:consumer && npm run test:tokens && npm run test:types && npm run test:visual && npm run release:verify && npm pack --workspace @workspace/ui --dry-run",
+    "release:dry-run": "npm run lint && npm run test && npm run typecheck && npm --workspace @workspace/docs run build && npm run test:consumer && npm run test:tokens && npm run test:types && npm run test:visual && npm run release:verify && npm pack --workspace @workspace/ui --dry-run",
     "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck && npm --workspace @workspace/consumer-fixture run typecheck"
   },
   "dependencies": {

--- a/scripts/verify-quality-gates.mjs
+++ b/scripts/verify-quality-gates.mjs
@@ -1,0 +1,71 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const ignoredDirectories = new Set([".git", "node_modules", "dist", "artifacts", "coverage"]);
+const scopeRules = [
+  { name: "TypeScript/JavaScript", extensions: [".ts", ".tsx", ".mjs", ".js"] },
+  { name: "CSS", extensions: [".css"] },
+  { name: "Markdown", extensions: [".md"] },
+  { name: "JSON/YAML", extensions: [".json", ".yml", ".yaml"] }
+];
+const failures = [];
+
+function getScope(filePath) {
+  return scopeRules.find((scope) => scope.extensions.some((extension) => filePath.endsWith(extension)));
+}
+
+async function collectFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (ignoredDirectories.has(entry.name)) continue;
+      files.push(...await collectFiles(join(directory, entry.name)));
+      continue;
+    }
+    if (entry.isFile()) files.push(join(directory, entry.name));
+  }
+  return files;
+}
+
+const files = (await collectFiles(rootDir)).filter((filePath) => getScope(filePath));
+const scopeCounts = new Map(scopeRules.map((scope) => [scope.name, 0]));
+
+for (const filePath of files) {
+  const scope = getScope(filePath);
+  scopeCounts.set(scope.name, (scopeCounts.get(scope.name) ?? 0) + 1);
+  const relativePath = relative(rootDir, filePath);
+  const content = await readFile(filePath, "utf8");
+  const lines = content.split("\n");
+
+  if (content.includes("\r\n")) {
+    failures.push(`${relativePath}: CRLF 줄바꿈을 사용합니다. / Uses CRLF line endings.`);
+  }
+  if (/^(<<<<<<< |=======|>>>>>>> )/m.test(content)) {
+    failures.push(`${relativePath}: merge conflict marker가 남아 있습니다. / Contains merge conflict markers.`);
+  }
+  if (!content.endsWith("\n")) {
+    failures.push(`${relativePath}: 파일 끝 newline이 없습니다. / Missing trailing newline.`);
+  }
+
+  lines.forEach((line, index) => {
+    if (/[ \t]+$/.test(line)) {
+      failures.push(`${relativePath}:${index + 1}: trailing whitespace가 있습니다. / Contains trailing whitespace.`);
+    }
+    if (scope.name !== "Markdown" && /^\t+/.test(line)) {
+      failures.push(`${relativePath}:${index + 1}: tab indentation을 사용합니다. / Uses tab indentation.`);
+    }
+  });
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+
+const summary = Array.from(scopeCounts.entries())
+  .map(([scopeName, count]) => `${scopeName} ${count}`)
+  .join(", ");
+console.log(`품질 게이트 검증 완료: ${summary}. / Quality gates passed: ${summary}.`);


### PR DESCRIPTION
## 변경 사항 / Changes
- repo 전용 최소 lint/format 품질 게이트 `npm run lint`를 추가했습니다. / Added the repo-specific minimal lint/format quality gate `npm run lint`.
- TypeScript/TSX/MJS/JS, CSS, Markdown, JSON/YAML 범위를 나눠 CRLF, trailing whitespace, tab indentation, merge conflict marker, final newline을 검증합니다. / Splits TypeScript/TSX/MJS/JS, CSS, Markdown, and JSON/YAML scopes and checks CRLF, trailing whitespace, tab indentation, merge conflict markers, and final newlines.
- CI와 release dry-run에 lint gate를 추가했습니다. / Added the lint gate to CI and release dry-run.
- `docs/quality-gates.md`, README, release checklist를 갱신했습니다. / Updated `docs/quality-gates.md`, README, and release checklist.

## 검증 / Verification
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run test:tokens`
- `npm run test:types`
- `npm run test:consumer`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

Closes #24
