### PR TITLE
[codex] Automate component prop tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ All notable changes are documented in this file.
 - release prepare, dry-run, publish workflow 자동화를 추가했습니다. / Added release prepare, dry-run, and publish workflow automation.
 - lint/format 최소 품질 게이트 `npm run lint`를 추가했습니다. / Added the minimal lint/format quality gate `npm run lint`.
 - docs app responsive, theme switch, Tab focus browser smoke 검증 `test:docs-smoke`를 추가했습니다. / Added `test:docs-smoke` browser smoke validation for docs app responsive layout, theme switching, and Tab focus.
+- prop-heavy component README/spec용 prop table metadata와 검증을 추가했습니다. / Added prop table metadata and validation for prop-heavy component README/spec docs.
 
 ### Changed
 
 - review/issue 운영 문서에 priority SLA, milestone 기준, follow-up 연결 규칙을 보강했습니다. / Strengthened review and issue operations docs with priority SLA, milestone criteria, and follow-up linking rules.
 - DataGrid 문서와 catalog prop 목록을 실제 상호작용 API에 맞췄습니다. / Aligned DataGrid docs and catalog prop lists with the actual interaction APIs.
+- scaffold가 기존 README/spec를 기본적으로 보존하고 `--force-docs`에서만 문서를 재생성하도록 바꿨습니다. / Changed scaffold behavior so existing README/spec files are preserved by default and regenerated only with `--force-docs`.

--- a/docs/component-authoring.md
+++ b/docs/component-authoring.md
@@ -37,6 +37,13 @@ Every component documents the items below before implementation.
 - Tokens: 사용하는 semantic/component token / Semantic and component tokens used
 - Test Plan: 최소 검증 범위 / Minimum verification scope
 
+## Prop 문서 자동화 / Prop Documentation Automation
+
+- `catalog.ts`의 `props`는 README와 spec의 `Prop 축 / Prop Axes` 기준입니다. / `props` in `catalog.ts` are the source for `Prop Axes` in README and spec files.
+- 상세 prop table은 `packages/ui/src/components/prop-docs.ts`에서 관리하고 scaffold가 `Prop 표 / Prop Table`로 렌더링합니다. / Detailed prop tables are managed in `packages/ui/src/components/prop-docs.ts` and rendered by the scaffold as `Prop Table`.
+- `DataGrid`, `Combobox`, `CommandPalette`처럼 prop이 많은 컴포넌트는 source props와 prop table이 `npm run components:validate`에서 함께 검증됩니다. / Prop-heavy components such as `DataGrid`, `Combobox`, and `CommandPalette` validate source props and prop tables together through `npm run components:validate`.
+- 기존 README/spec는 기본적으로 보존됩니다. 강제로 문서를 재생성해야 할 때만 사용자 수동 변경 여부를 확인한 뒤 `npm run components:scaffold -- --force-docs`를 사용합니다. / Existing README/spec files are preserved by default. Use `npm run components:scaffold -- --force-docs` only after checking for user-authored manual changes.
+
 ## 구현 규칙 / Implementation Rules
 
 - native element로 해결 가능한 경우 custom role을 만들지 않습니다. / Do not create a custom role when a native element can solve the problem.

--- a/packages/ui/src/components/README.md
+++ b/packages/ui/src/components/README.md
@@ -8,8 +8,8 @@ This directory contains the component catalog, documentation, and individual imp
 각 컴포넌트 폴더는 구현과 문서를 같은 위치에 둡니다.
 Each component folder keeps implementation and documentation in the same location.
 
-- `README.md`: 역할, 사용 기준, prop 축, 상태, 접근성, 토큰, 예시를 설명합니다. / Explains role, usage criteria, prop axes, states, accessibility, tokens, and examples.
-- `spec.md`: API 표면, 상태 동작, 상호작용, 접근성 계약, 검증 체크리스트를 정의합니다. / Defines API surface, state behavior, interaction, accessibility contract, and validation checklist.
+- `README.md`: 역할, 사용 기준, prop 축, prop 표, 상태, 접근성, 토큰, 예시를 설명합니다. / Explains role, usage criteria, prop axes, prop tables, states, accessibility, tokens, and examples.
+- `spec.md`: API 표면, prop 표, 상태 동작, 상호작용, 접근성 계약, 검증 체크리스트를 정의합니다. / Defines API surface, prop tables, state behavior, interaction, accessibility contract, and validation checklist.
 - `{component-slug}.tsx`: 실제 React + TypeScript 구현입니다. / The actual React + TypeScript implementation.
 - `index.ts`: 해당 컴포넌트의 public entry입니다. / The public entry for the component.
 
@@ -46,6 +46,7 @@ The component catalog in `catalog.ts` is the source for initial scaffolding and 
 - 컴포넌트 색상은 theme name이 아니라 semantic token을 통해 설명합니다. / Component color is described through semantic tokens, not theme names.
 - 접근성 항목은 native HTML 기준과 WAI-ARIA APG 링크 중 해당하는 기준을 명시합니다. / Accessibility items state the relevant native HTML baseline or WAI-ARIA APG link.
 - README와 spec은 `catalog.ts`의 props, states, tokens와 어긋나지 않아야 합니다. / README and spec must stay aligned with props, states, and tokens in `catalog.ts`.
+- prop table metadata는 `prop-docs.ts`에 두고, prop-heavy 컴포넌트는 source props와 table 항목이 검증에서 일치해야 합니다. / Prop table metadata lives in `prop-docs.ts`, and prop-heavy components must keep source props aligned with table entries during validation.
 
 ## 검증 / Validation
 
@@ -58,3 +59,6 @@ npm run components:validate
 
 문서만 수정했더라도 public export, 폴더 구조, 토큰 계약이 함께 깨지지 않았는지 확인합니다.
 Even documentation-only changes should confirm that public exports, folder structure, and token contracts still hold.
+
+기존 수동 문서를 덮어쓰지 않기 위해 scaffold는 README/spec를 기본적으로 보존합니다. 문서를 재생성해야 할 때만 변경분을 먼저 확인하고 `npm run components:scaffold -- --force-docs`를 실행합니다.
+The scaffold preserves existing README/spec files by default. Regenerate docs only after checking local changes, then run `npm run components:scaffold -- --force-docs`.

--- a/packages/ui/src/components/catalog.ts
+++ b/packages/ui/src/components/catalog.ts
@@ -189,7 +189,7 @@ export const componentCatalog: ComponentCatalogItem[] = [
     purpose: "Use when a select needs filtering, text input, or many options without leaving the current form.",
     primitive: "combobox with listbox popup",
     apg: "https://www.w3.org/WAI/ARIA/apg/patterns/combobox/",
-    props: ["value", "defaultValue", "options", "placeholder", "size", "width", "fieldProps", "emptyMessage", "onValueChange", "disabled", "invalid"],
+    props: ["label", "description", "error", "value", "defaultValue", "options", "placeholder", "emptyMessage", "size", "width", "disabled", "required", "fieldProps", "onValueChange"],
     states: ["closed", "open", "filtered", "highlighted", "selected", "disabled", "invalid"],
     tokens: ["--ds-color-bg-surface", "--ds-color-border-default", "--ds-focus-ring"]
   },
@@ -385,7 +385,7 @@ export const componentCatalog: ComponentCatalogItem[] = [
     purpose: "Use for global command discovery, quick navigation, and shortcut-driven actions.",
     primitive: "dialog with combobox-style command list",
     apg: "https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/",
-    props: ["open", "defaultOpen", "commands", "placeholder", "emptyMessage", "title", "onOpenChange", "onCommandSelect"],
+    props: ["title", "triggerLabel", "commands", "open", "defaultOpen", "placeholder", "emptyMessage", "onOpenChange", "onCommandSelect"],
     states: ["closed", "open", "filtered", "highlighted", "empty"],
     tokens: ["--ds-z-dialog", "--ds-shadow-raised", "--ds-focus-ring"]
   },
@@ -521,11 +521,11 @@ export const componentCatalog: ComponentCatalogItem[] = [
     category: "data-display",
     priority: "P0",
     status: "ready",
-    summary: "Interactive tabular grid with sorting, selection, and row actions.",
+    summary: "Interactive tabular grid with sorting, selection, row actions, keyboard row navigation, and column resize.",
     purpose: "Use when dense records need structured scanning with richer controls than a static table.",
     primitive: "table with grid-like interactions",
     apg: "https://www.w3.org/WAI/ARIA/apg/patterns/grid/",
-    props: ["columns", "rows", "density", "sortable", "selectionMode", "striped", "stickyHeader", "emptyMessage", "rowKey", "rowActions", "sortState", "defaultSortState", "selectedRowKeys", "defaultSelectedRowKeys", "activeRowKey", "defaultActiveRowKey", "keyboardNavigation", "resizableColumns", "onSortChange", "onSelectedRowKeysChange", "onSelectionChange", "onActiveRowKeyChange", "onColumnResize"],
+    props: ["caption", "columns", "rows", "density", "sortable", "selectionMode", "striped", "stickyHeader", "loading", "emptyMessage", "rowKey", "rowActions", "sortState", "defaultSortState", "selectedRowKeys", "defaultSelectedRowKeys", "activeRowKey", "defaultActiveRowKey", "keyboardNavigation", "resizableColumns", "onSort", "onSortChange", "onSelectedRowKeysChange", "onSelectionChange", "onActiveRowKeyChange", "onColumnResize"],
     states: ["default", "hover", "sorted", "selected", "active", "empty", "loading", "resizing"],
     tokens: ["--ds-color-border-default", "--ds-color-bg-surface", "--ds-color-bg-muted"]
   },

--- a/packages/ui/src/components/data-display/data-grid/README.md
+++ b/packages/ui/src/components/data-display/data-grid/README.md
@@ -15,7 +15,38 @@
 
 ## Prop 축 / Prop Axes
 
-`columns`, `rows`, `density`, `sortable`, `selectionMode`, `striped`, `stickyHeader`, `emptyMessage`, `rowKey`, `rowActions`, `sortState`, `defaultSortState`, `selectedRowKeys`, `defaultSelectedRowKeys`, `activeRowKey`, `defaultActiveRowKey`, `keyboardNavigation`, `resizableColumns`, `onSortChange`, `onSelectedRowKeysChange`, `onSelectionChange`, `onActiveRowKeyChange`, `onColumnResize`
+`caption`, `columns`, `rows`, `density`, `sortable`, `selectionMode`, `striped`, `stickyHeader`, `loading`, `emptyMessage`, `rowKey`, `rowActions`, `sortState`, `defaultSortState`, `selectedRowKeys`, `defaultSelectedRowKeys`, `activeRowKey`, `defaultActiveRowKey`, `keyboardNavigation`, `resizableColumns`, `onSort`, `onSortChange`, `onSelectedRowKeysChange`, `onSelectionChange`, `onActiveRowKeyChange`, `onColumnResize`
+
+## Prop 표 / Prop Table
+
+| Prop | Type | Default | 설명 / Description |
+| --- | --- | --- | --- |
+| `caption` | `ReactNode` | `-` | table caption입니다. / Table caption. |
+| `columns` | `Array<DataGridColumn<Row>>` | `[]` | column 구조와 render 설정입니다. / Column structure and render settings. |
+| `rows` | `Row[]` | `[]` | 렌더링할 row 데이터입니다. / Row data to render. |
+| `density` | `"compact" \| "md"` | `"md"` | row와 cell 밀도입니다. / Row and cell density. |
+| `sortable` | `boolean` | `true` | 전체 column sort control 기본값입니다. / Default sort control behavior for columns. |
+| `selectionMode` | `"none" \| "multiple"` | `"none"` | row selection 모드입니다. / Row selection mode. |
+| `striped` | `boolean` | `true` | 교차 row 배경을 표시합니다. / Shows alternating row backgrounds. |
+| `stickyHeader` | `boolean` | `false` | header를 sticky로 유지합니다. / Keeps the header sticky. |
+| `loading` | `boolean` | `false` | loading 상태와 `aria-busy`를 표시합니다. / Shows loading state and `aria-busy`. |
+| `emptyMessage` | `ReactNode` | `"데이터가 없습니다. / No data."` | row가 없을 때 표시합니다. / Shown when there are no rows. |
+| `rowKey` | `(row: Row, rowIndex: number) => string` | `rowIndex` | row identity를 계산합니다. / Computes row identity. |
+| `rowActions` | `(row: Row, rowIndex: number) => ReactNode` | `-` | row action cell을 렌더링합니다. / Renders the row action cell. |
+| `sortState` | `TableSortState<Row>` | `-` | controlled sort 상태입니다. / Controlled sort state. |
+| `defaultSortState` | `TableSortState<Row>` | `-` | uncontrolled 초기 sort 상태입니다. / Initial uncontrolled sort state. |
+| `selectedRowKeys` | `string[]` | `-` | controlled selected row key 목록입니다. / Controlled selected row keys. |
+| `defaultSelectedRowKeys` | `string[]` | `[]` | uncontrolled 초기 selected row key 목록입니다. / Initial uncontrolled selected row keys. |
+| `activeRowKey` | `string` | `-` | controlled active row key입니다. / Controlled active row key. |
+| `defaultActiveRowKey` | `string` | `첫 row key / First row key` | uncontrolled 초기 active row key입니다. / Initial uncontrolled active row key. |
+| `keyboardNavigation` | `"row" \| "none"` | `"row"` | roving row keyboard navigation 사용 여부입니다. / Enables roving row keyboard navigation. |
+| `resizableColumns` | `boolean` | `true` | column resize handle을 활성화합니다. / Enables column resize handles. |
+| `onSort` | `(key: keyof Row & string) => void` | `-` | legacy sort callback입니다. / Legacy sort callback. |
+| `onSortChange` | `(sortState: TableSortState<Row> \| undefined) => void` | `-` | sort 상태가 바뀔 때 호출됩니다. / Called when sort state changes. |
+| `onSelectedRowKeysChange` | `(keys: string[]) => void` | `-` | selected key 목록이 바뀔 때 호출됩니다. / Called when selected keys change. |
+| `onSelectionChange` | `(rows: Row[]) => void` | `-` | 선택된 row 목록이 바뀔 때 호출됩니다. / Called when selected rows change. |
+| `onActiveRowKeyChange` | `(key: string \| undefined, row: Row \| undefined) => void` | `-` | active row가 바뀔 때 호출됩니다. / Called when the active row changes. |
+| `onColumnResize` | `(key: keyof Row & string, width: number) => void` | `-` | column width가 바뀔 때 호출됩니다. / Called when a column width changes. |
 
 ## 상태 / States
 

--- a/packages/ui/src/components/data-display/data-grid/spec.md
+++ b/packages/ui/src/components/data-display/data-grid/spec.md
@@ -10,7 +10,38 @@
 - folder slug: `data-grid`
 - category: `data-display`
 - priority/status: `P0` / `ready`
-- props: `columns`, `rows`, `density`, `sortable`, `selectionMode`, `striped`, `stickyHeader`, `emptyMessage`, `rowKey`, `rowActions`, `sortState`, `defaultSortState`, `selectedRowKeys`, `defaultSelectedRowKeys`, `activeRowKey`, `defaultActiveRowKey`, `keyboardNavigation`, `resizableColumns`, `onSortChange`, `onSelectedRowKeysChange`, `onSelectionChange`, `onActiveRowKeyChange`, `onColumnResize`
+- props: `caption`, `columns`, `rows`, `density`, `sortable`, `selectionMode`, `striped`, `stickyHeader`, `loading`, `emptyMessage`, `rowKey`, `rowActions`, `sortState`, `defaultSortState`, `selectedRowKeys`, `defaultSelectedRowKeys`, `activeRowKey`, `defaultActiveRowKey`, `keyboardNavigation`, `resizableColumns`, `onSort`, `onSortChange`, `onSelectedRowKeysChange`, `onSelectionChange`, `onActiveRowKeyChange`, `onColumnResize`
+
+## Prop 표 / Prop Table
+
+| Prop | Type | Default | 설명 / Description |
+| --- | --- | --- | --- |
+| `caption` | `ReactNode` | `-` | table caption입니다. / Table caption. |
+| `columns` | `Array<DataGridColumn<Row>>` | `[]` | column 구조와 render 설정입니다. / Column structure and render settings. |
+| `rows` | `Row[]` | `[]` | 렌더링할 row 데이터입니다. / Row data to render. |
+| `density` | `"compact" \| "md"` | `"md"` | row와 cell 밀도입니다. / Row and cell density. |
+| `sortable` | `boolean` | `true` | 전체 column sort control 기본값입니다. / Default sort control behavior for columns. |
+| `selectionMode` | `"none" \| "multiple"` | `"none"` | row selection 모드입니다. / Row selection mode. |
+| `striped` | `boolean` | `true` | 교차 row 배경을 표시합니다. / Shows alternating row backgrounds. |
+| `stickyHeader` | `boolean` | `false` | header를 sticky로 유지합니다. / Keeps the header sticky. |
+| `loading` | `boolean` | `false` | loading 상태와 `aria-busy`를 표시합니다. / Shows loading state and `aria-busy`. |
+| `emptyMessage` | `ReactNode` | `"데이터가 없습니다. / No data."` | row가 없을 때 표시합니다. / Shown when there are no rows. |
+| `rowKey` | `(row: Row, rowIndex: number) => string` | `rowIndex` | row identity를 계산합니다. / Computes row identity. |
+| `rowActions` | `(row: Row, rowIndex: number) => ReactNode` | `-` | row action cell을 렌더링합니다. / Renders the row action cell. |
+| `sortState` | `TableSortState<Row>` | `-` | controlled sort 상태입니다. / Controlled sort state. |
+| `defaultSortState` | `TableSortState<Row>` | `-` | uncontrolled 초기 sort 상태입니다. / Initial uncontrolled sort state. |
+| `selectedRowKeys` | `string[]` | `-` | controlled selected row key 목록입니다. / Controlled selected row keys. |
+| `defaultSelectedRowKeys` | `string[]` | `[]` | uncontrolled 초기 selected row key 목록입니다. / Initial uncontrolled selected row keys. |
+| `activeRowKey` | `string` | `-` | controlled active row key입니다. / Controlled active row key. |
+| `defaultActiveRowKey` | `string` | `첫 row key / First row key` | uncontrolled 초기 active row key입니다. / Initial uncontrolled active row key. |
+| `keyboardNavigation` | `"row" \| "none"` | `"row"` | roving row keyboard navigation 사용 여부입니다. / Enables roving row keyboard navigation. |
+| `resizableColumns` | `boolean` | `true` | column resize handle을 활성화합니다. / Enables column resize handles. |
+| `onSort` | `(key: keyof Row & string) => void` | `-` | legacy sort callback입니다. / Legacy sort callback. |
+| `onSortChange` | `(sortState: TableSortState<Row> \| undefined) => void` | `-` | sort 상태가 바뀔 때 호출됩니다. / Called when sort state changes. |
+| `onSelectedRowKeysChange` | `(keys: string[]) => void` | `-` | selected key 목록이 바뀔 때 호출됩니다. / Called when selected keys change. |
+| `onSelectionChange` | `(rows: Row[]) => void` | `-` | 선택된 row 목록이 바뀔 때 호출됩니다. / Called when selected rows change. |
+| `onActiveRowKeyChange` | `(key: string \| undefined, row: Row \| undefined) => void` | `-` | active row가 바뀔 때 호출됩니다. / Called when the active row changes. |
+| `onColumnResize` | `(key: keyof Row & string, width: number) => void` | `-` | column width가 바뀔 때 호출됩니다. / Called when a column width changes. |
 
 ## 변형 / Variants
 

--- a/packages/ui/src/components/forms/combobox/README.md
+++ b/packages/ui/src/components/forms/combobox/README.md
@@ -15,7 +15,26 @@
 
 ## Prop 축 / Prop Axes
 
-`value`, `defaultValue`, `options`, `placeholder`, `size`, `width`, `fieldProps`, `emptyMessage`, `onValueChange`, `disabled`, `invalid`
+`label`, `description`, `error`, `value`, `defaultValue`, `options`, `placeholder`, `emptyMessage`, `size`, `width`, `disabled`, `required`, `fieldProps`, `onValueChange`
+
+## Prop 표 / Prop Table
+
+| Prop | Type | Default | 설명 / Description |
+| --- | --- | --- | --- |
+| `label` | `ReactNode` | `-` | 필드 label입니다. / Field label. |
+| `description` | `ReactNode` | `-` | 보조 설명입니다. / Helper description. |
+| `error` | `ReactNode` | `-` | 오류 메시지이며 invalid 상태를 만듭니다. / Error message that creates the invalid state. |
+| `value` | `string` | `-` | controlled 선택 값입니다. / Controlled selected value. |
+| `defaultValue` | `string` | `""` | uncontrolled 초기 선택 값입니다. / Initial uncontrolled selected value. |
+| `options` | `ComboboxOption[]` | `[]` | 검색하고 선택할 option 목록입니다. / Options available for filtering and selection. |
+| `placeholder` | `string` | `"검색 또는 선택 / Search or select"` | 입력 placeholder입니다. / Input placeholder. |
+| `emptyMessage` | `ReactNode` | `"결과가 없습니다. / No results."` | 필터 결과가 없을 때 표시합니다. / Shown when filtering returns no options. |
+| `size` | `Size` | `"md"` | control 높이와 밀도입니다. / Control height and density. |
+| `width` | `FieldWidth` | `"auto"` | Field wrapper 폭입니다. / Field wrapper width. |
+| `disabled` | `boolean` | `false` | 입력과 toggle을 비활성화합니다. / Disables the input and toggle. |
+| `required` | `boolean` | `false` | 필수 입력 상태를 표시합니다. / Marks the field as required. |
+| `fieldProps` | `Omit<FieldProps, ...>` | `-` | Field wrapper에 전달할 추가 설정입니다. / Additional settings passed to the Field wrapper. |
+| `onValueChange` | `(value: string) => void` | `-` | 선택 값이 바뀔 때 호출됩니다. / Called when the selected value changes. |
 
 ## 상태 / States
 

--- a/packages/ui/src/components/forms/combobox/spec.md
+++ b/packages/ui/src/components/forms/combobox/spec.md
@@ -10,7 +10,26 @@
 - folder slug: `combobox`
 - category: `forms`
 - priority/status: `P0` / `ready`
-- props: `value`, `defaultValue`, `options`, `placeholder`, `size`, `width`, `fieldProps`, `emptyMessage`, `onValueChange`, `disabled`, `invalid`
+- props: `label`, `description`, `error`, `value`, `defaultValue`, `options`, `placeholder`, `emptyMessage`, `size`, `width`, `disabled`, `required`, `fieldProps`, `onValueChange`
+
+## Prop 표 / Prop Table
+
+| Prop | Type | Default | 설명 / Description |
+| --- | --- | --- | --- |
+| `label` | `ReactNode` | `-` | 필드 label입니다. / Field label. |
+| `description` | `ReactNode` | `-` | 보조 설명입니다. / Helper description. |
+| `error` | `ReactNode` | `-` | 오류 메시지이며 invalid 상태를 만듭니다. / Error message that creates the invalid state. |
+| `value` | `string` | `-` | controlled 선택 값입니다. / Controlled selected value. |
+| `defaultValue` | `string` | `""` | uncontrolled 초기 선택 값입니다. / Initial uncontrolled selected value. |
+| `options` | `ComboboxOption[]` | `[]` | 검색하고 선택할 option 목록입니다. / Options available for filtering and selection. |
+| `placeholder` | `string` | `"검색 또는 선택 / Search or select"` | 입력 placeholder입니다. / Input placeholder. |
+| `emptyMessage` | `ReactNode` | `"결과가 없습니다. / No results."` | 필터 결과가 없을 때 표시합니다. / Shown when filtering returns no options. |
+| `size` | `Size` | `"md"` | control 높이와 밀도입니다. / Control height and density. |
+| `width` | `FieldWidth` | `"auto"` | Field wrapper 폭입니다. / Field wrapper width. |
+| `disabled` | `boolean` | `false` | 입력과 toggle을 비활성화합니다. / Disables the input and toggle. |
+| `required` | `boolean` | `false` | 필수 입력 상태를 표시합니다. / Marks the field as required. |
+| `fieldProps` | `Omit<FieldProps, ...>` | `-` | Field wrapper에 전달할 추가 설정입니다. / Additional settings passed to the Field wrapper. |
+| `onValueChange` | `(value: string) => void` | `-` | 선택 값이 바뀔 때 호출됩니다. / Called when the selected value changes. |
 
 ## 변형 / Variants
 

--- a/packages/ui/src/components/overlays/command-palette/README.md
+++ b/packages/ui/src/components/overlays/command-palette/README.md
@@ -15,7 +15,21 @@
 
 ## Prop 축 / Prop Axes
 
-`open`, `defaultOpen`, `commands`, `placeholder`, `emptyMessage`, `title`, `onOpenChange`, `onCommandSelect`
+`title`, `triggerLabel`, `commands`, `open`, `defaultOpen`, `placeholder`, `emptyMessage`, `onOpenChange`, `onCommandSelect`
+
+## Prop 표 / Prop Table
+
+| Prop | Type | Default | 설명 / Description |
+| --- | --- | --- | --- |
+| `title` | `ReactNode` | `"명령 팔레트 / Command palette"` | dialog 제목입니다. / Dialog title. |
+| `triggerLabel` | `ReactNode` | `"명령 열기 / Open commands"` | palette를 여는 trigger button label입니다. / Trigger button label that opens the palette. |
+| `commands` | `CommandPaletteCommand[]` | `[]` | 검색하고 실행할 command 목록입니다. / Commands available for search and execution. |
+| `open` | `boolean` | `-` | controlled open 상태입니다. / Controlled open state. |
+| `defaultOpen` | `boolean` | `false` | uncontrolled 초기 open 상태입니다. / Initial uncontrolled open state. |
+| `placeholder` | `string` | `"명령 검색 / Search commands"` | 검색 input placeholder입니다. / Search input placeholder. |
+| `emptyMessage` | `ReactNode` | `"명령이 없습니다. / No commands."` | 검색 결과가 없을 때 표시합니다. / Shown when no commands match. |
+| `onOpenChange` | `(open: boolean) => void` | `-` | open 상태가 바뀔 때 호출됩니다. / Called when open state changes. |
+| `onCommandSelect` | `(command: CommandPaletteCommand) => void` | `-` | command가 선택될 때 호출됩니다. / Called when a command is selected. |
 
 ## 상태 / States
 

--- a/packages/ui/src/components/overlays/command-palette/spec.md
+++ b/packages/ui/src/components/overlays/command-palette/spec.md
@@ -10,7 +10,21 @@
 - folder slug: `command-palette`
 - category: `overlays`
 - priority/status: `P1` / `ready`
-- props: `open`, `defaultOpen`, `commands`, `placeholder`, `emptyMessage`, `title`, `onOpenChange`, `onCommandSelect`
+- props: `title`, `triggerLabel`, `commands`, `open`, `defaultOpen`, `placeholder`, `emptyMessage`, `onOpenChange`, `onCommandSelect`
+
+## Prop 표 / Prop Table
+
+| Prop | Type | Default | 설명 / Description |
+| --- | --- | --- | --- |
+| `title` | `ReactNode` | `"명령 팔레트 / Command palette"` | dialog 제목입니다. / Dialog title. |
+| `triggerLabel` | `ReactNode` | `"명령 열기 / Open commands"` | palette를 여는 trigger button label입니다. / Trigger button label that opens the palette. |
+| `commands` | `CommandPaletteCommand[]` | `[]` | 검색하고 실행할 command 목록입니다. / Commands available for search and execution. |
+| `open` | `boolean` | `-` | controlled open 상태입니다. / Controlled open state. |
+| `defaultOpen` | `boolean` | `false` | uncontrolled 초기 open 상태입니다. / Initial uncontrolled open state. |
+| `placeholder` | `string` | `"명령 검색 / Search commands"` | 검색 input placeholder입니다. / Search input placeholder. |
+| `emptyMessage` | `ReactNode` | `"명령이 없습니다. / No commands."` | 검색 결과가 없을 때 표시합니다. / Shown when no commands match. |
+| `onOpenChange` | `(open: boolean) => void` | `-` | open 상태가 바뀔 때 호출됩니다. / Called when open state changes. |
+| `onCommandSelect` | `(command: CommandPaletteCommand) => void` | `-` | command가 선택될 때 호출됩니다. / Called when a command is selected. |
 
 ## 변형 / Variants
 

--- a/packages/ui/src/components/prop-docs.ts
+++ b/packages/ui/src/components/prop-docs.ts
@@ -1,0 +1,91 @@
+export interface ComponentPropDoc {
+  name: string;
+  type: string;
+  defaultValue: string;
+  description: string;
+}
+
+export interface ComponentPropDocSource {
+  name: string;
+  props: string[];
+}
+
+export const componentPropDocs: Record<string, ComponentPropDoc[]> = {
+  Combobox: [
+    { name: "label", type: "ReactNode", defaultValue: "-", description: "필드 label입니다. / Field label." },
+    { name: "description", type: "ReactNode", defaultValue: "-", description: "보조 설명입니다. / Helper description." },
+    { name: "error", type: "ReactNode", defaultValue: "-", description: "오류 메시지이며 invalid 상태를 만듭니다. / Error message that creates the invalid state." },
+    { name: "value", type: "string", defaultValue: "-", description: "controlled 선택 값입니다. / Controlled selected value." },
+    { name: "defaultValue", type: "string", defaultValue: "\"\"", description: "uncontrolled 초기 선택 값입니다. / Initial uncontrolled selected value." },
+    { name: "options", type: "ComboboxOption[]", defaultValue: "[]", description: "검색하고 선택할 option 목록입니다. / Options available for filtering and selection." },
+    { name: "placeholder", type: "string", defaultValue: "\"검색 또는 선택 / Search or select\"", description: "입력 placeholder입니다. / Input placeholder." },
+    { name: "emptyMessage", type: "ReactNode", defaultValue: "\"결과가 없습니다. / No results.\"", description: "필터 결과가 없을 때 표시합니다. / Shown when filtering returns no options." },
+    { name: "size", type: "Size", defaultValue: "\"md\"", description: "control 높이와 밀도입니다. / Control height and density." },
+    { name: "width", type: "FieldWidth", defaultValue: "\"auto\"", description: "Field wrapper 폭입니다. / Field wrapper width." },
+    { name: "disabled", type: "boolean", defaultValue: "false", description: "입력과 toggle을 비활성화합니다. / Disables the input and toggle." },
+    { name: "required", type: "boolean", defaultValue: "false", description: "필수 입력 상태를 표시합니다. / Marks the field as required." },
+    { name: "fieldProps", type: "Omit<FieldProps, ...>", defaultValue: "-", description: "Field wrapper에 전달할 추가 설정입니다. / Additional settings passed to the Field wrapper." },
+    { name: "onValueChange", type: "(value: string) => void", defaultValue: "-", description: "선택 값이 바뀔 때 호출됩니다. / Called when the selected value changes." }
+  ],
+  CommandPalette: [
+    { name: "title", type: "ReactNode", defaultValue: "\"명령 팔레트 / Command palette\"", description: "dialog 제목입니다. / Dialog title." },
+    { name: "triggerLabel", type: "ReactNode", defaultValue: "\"명령 열기 / Open commands\"", description: "palette를 여는 trigger button label입니다. / Trigger button label that opens the palette." },
+    { name: "commands", type: "CommandPaletteCommand[]", defaultValue: "[]", description: "검색하고 실행할 command 목록입니다. / Commands available for search and execution." },
+    { name: "open", type: "boolean", defaultValue: "-", description: "controlled open 상태입니다. / Controlled open state." },
+    { name: "defaultOpen", type: "boolean", defaultValue: "false", description: "uncontrolled 초기 open 상태입니다. / Initial uncontrolled open state." },
+    { name: "placeholder", type: "string", defaultValue: "\"명령 검색 / Search commands\"", description: "검색 input placeholder입니다. / Search input placeholder." },
+    { name: "emptyMessage", type: "ReactNode", defaultValue: "\"명령이 없습니다. / No commands.\"", description: "검색 결과가 없을 때 표시합니다. / Shown when no commands match." },
+    { name: "onOpenChange", type: "(open: boolean) => void", defaultValue: "-", description: "open 상태가 바뀔 때 호출됩니다. / Called when open state changes." },
+    { name: "onCommandSelect", type: "(command: CommandPaletteCommand) => void", defaultValue: "-", description: "command가 선택될 때 호출됩니다. / Called when a command is selected." }
+  ],
+  DataGrid: [
+    { name: "caption", type: "ReactNode", defaultValue: "-", description: "table caption입니다. / Table caption." },
+    { name: "columns", type: "Array<DataGridColumn<Row>>", defaultValue: "[]", description: "column 구조와 render 설정입니다. / Column structure and render settings." },
+    { name: "rows", type: "Row[]", defaultValue: "[]", description: "렌더링할 row 데이터입니다. / Row data to render." },
+    { name: "density", type: "\"compact\" | \"md\"", defaultValue: "\"md\"", description: "row와 cell 밀도입니다. / Row and cell density." },
+    { name: "sortable", type: "boolean", defaultValue: "true", description: "전체 column sort control 기본값입니다. / Default sort control behavior for columns." },
+    { name: "selectionMode", type: "\"none\" | \"multiple\"", defaultValue: "\"none\"", description: "row selection 모드입니다. / Row selection mode." },
+    { name: "striped", type: "boolean", defaultValue: "true", description: "교차 row 배경을 표시합니다. / Shows alternating row backgrounds." },
+    { name: "stickyHeader", type: "boolean", defaultValue: "false", description: "header를 sticky로 유지합니다. / Keeps the header sticky." },
+    { name: "loading", type: "boolean", defaultValue: "false", description: "loading 상태와 `aria-busy`를 표시합니다. / Shows loading state and `aria-busy`." },
+    { name: "emptyMessage", type: "ReactNode", defaultValue: "\"데이터가 없습니다. / No data.\"", description: "row가 없을 때 표시합니다. / Shown when there are no rows." },
+    { name: "rowKey", type: "(row: Row, rowIndex: number) => string", defaultValue: "rowIndex", description: "row identity를 계산합니다. / Computes row identity." },
+    { name: "rowActions", type: "(row: Row, rowIndex: number) => ReactNode", defaultValue: "-", description: "row action cell을 렌더링합니다. / Renders the row action cell." },
+    { name: "sortState", type: "TableSortState<Row>", defaultValue: "-", description: "controlled sort 상태입니다. / Controlled sort state." },
+    { name: "defaultSortState", type: "TableSortState<Row>", defaultValue: "-", description: "uncontrolled 초기 sort 상태입니다. / Initial uncontrolled sort state." },
+    { name: "selectedRowKeys", type: "string[]", defaultValue: "-", description: "controlled selected row key 목록입니다. / Controlled selected row keys." },
+    { name: "defaultSelectedRowKeys", type: "string[]", defaultValue: "[]", description: "uncontrolled 초기 selected row key 목록입니다. / Initial uncontrolled selected row keys." },
+    { name: "activeRowKey", type: "string", defaultValue: "-", description: "controlled active row key입니다. / Controlled active row key." },
+    { name: "defaultActiveRowKey", type: "string", defaultValue: "첫 row key / First row key", description: "uncontrolled 초기 active row key입니다. / Initial uncontrolled active row key." },
+    { name: "keyboardNavigation", type: "\"row\" | \"none\"", defaultValue: "\"row\"", description: "roving row keyboard navigation 사용 여부입니다. / Enables roving row keyboard navigation." },
+    { name: "resizableColumns", type: "boolean", defaultValue: "true", description: "column resize handle을 활성화합니다. / Enables column resize handles." },
+    { name: "onSort", type: "(key: keyof Row & string) => void", defaultValue: "-", description: "legacy sort callback입니다. / Legacy sort callback." },
+    { name: "onSortChange", type: "(sortState: TableSortState<Row> | undefined) => void", defaultValue: "-", description: "sort 상태가 바뀔 때 호출됩니다. / Called when sort state changes." },
+    { name: "onSelectedRowKeysChange", type: "(keys: string[]) => void", defaultValue: "-", description: "selected key 목록이 바뀔 때 호출됩니다. / Called when selected keys change." },
+    { name: "onSelectionChange", type: "(rows: Row[]) => void", defaultValue: "-", description: "선택된 row 목록이 바뀔 때 호출됩니다. / Called when selected rows change." },
+    { name: "onActiveRowKeyChange", type: "(key: string | undefined, row: Row | undefined) => void", defaultValue: "-", description: "active row가 바뀔 때 호출됩니다. / Called when the active row changes." },
+    { name: "onColumnResize", type: "(key: keyof Row & string, width: number) => void", defaultValue: "-", description: "column width가 바뀔 때 호출됩니다. / Called when a column width changes." }
+  ]
+};
+
+function escapeTableCell(value: string) {
+  return value.replaceAll("|", "\\|");
+}
+
+export function getComponentPropDocs(component: ComponentPropDocSource) {
+  return componentPropDocs[component.name] ?? component.props.map((prop) => ({
+    name: prop,
+    type: "catalog",
+    defaultValue: "-",
+    description: "catalog prop 축에서 생성된 항목입니다. / Generated from the catalog prop axis."
+  }));
+}
+
+export function renderComponentPropTable(component: ComponentPropDocSource) {
+  const rows = getComponentPropDocs(component);
+  return [
+    "| Prop | Type | Default | 설명 / Description |",
+    "| --- | --- | --- | --- |",
+    ...rows.map((row) => `| \`${row.name}\` | \`${escapeTableCell(row.type)}\` | \`${escapeTableCell(row.defaultValue)}\` | ${escapeTableCell(row.description)} |`)
+  ].join("\n");
+}

--- a/scripts/scaffold-component-docs.mjs
+++ b/scripts/scaffold-component-docs.mjs
@@ -3,9 +3,11 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { componentCatalog, componentCategories } from "../packages/ui/src/components/catalog.ts";
+import { renderComponentPropTable } from "../packages/ui/src/components/prop-docs.ts";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const force = process.argv.includes("--force");
+const forceDocs = process.argv.includes("--force-docs");
 const categoryLabels = new Map(componentCategories.map((category) => [category.id, category.label]));
 const categoryKoreanLabels = new Map([
   ["actions", "액션"],
@@ -157,6 +159,10 @@ ${component.summary}
 
 ${renderList(component.props)}
 
+## Prop 표 / Prop Table
+
+${renderComponentPropTable(component)}
+
 ## 상태 / States
 
 ${renderList(component.states)}
@@ -223,6 +229,10 @@ TODO: 허용되는 variant와 각 variant가 적합한 상황을 정의합니다
 
 ${renderList(component.tokens)}
 
+## Prop 표 / Prop Table
+
+${renderComponentPropTable(component)}
+
 ## 테스트 계획 / Test Plan
 
 - 단위 동작 / Unit behavior: TODO
@@ -253,10 +263,11 @@ export function ${component.name}({ children, ...props }: ${component.name}Props
 `;
 }
 
-async function writeIfMissing(path, content) {
+async function writeIfMissing(path, content, options = {}) {
   await mkdir(dirname(path), { recursive: true });
 
-  if (!force && existsSync(path)) {
+  const canOverwrite = options.doc ? forceDocs : force;
+  if (existsSync(path) && !canOverwrite) {
     return false;
   }
 
@@ -277,11 +288,11 @@ for (const component of componentCatalog) {
     component.slug
   );
 
-  if (await writeIfMissing(join(componentDir, "README.md"), renderReadme(component))) {
+  if (await writeIfMissing(join(componentDir, "README.md"), renderReadme(component), { doc: true })) {
     written += 1;
   }
 
-  if (await writeIfMissing(join(componentDir, "spec.md"), renderSpec(component))) {
+  if (await writeIfMissing(join(componentDir, "spec.md"), renderSpec(component), { doc: true })) {
     written += 1;
   }
 

--- a/scripts/validate-component-system.mjs
+++ b/scripts/validate-component-system.mjs
@@ -2,6 +2,7 @@ import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { componentCatalog, componentCategories, componentStatuses } from "../packages/ui/src/components/catalog.ts";
+import { componentPropDocs, getComponentPropDocs } from "../packages/ui/src/components/prop-docs.ts";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const categoryIds = new Set(componentCategories.map((category) => category.id));
@@ -74,6 +75,29 @@ const implementationPaths = new Map([
   ["Stack", ["layout", "stack"]],
   ["Inline", ["layout", "inline"]]
 ]);
+const propTableHeader = "| Prop | Type | Default | 설명 / Description |";
+
+function extractInterfacePropNames(source, interfaceName) {
+  const interfaceIndex = source.indexOf(`interface ${interfaceName}`);
+  if (interfaceIndex === -1) return [];
+
+  const bodyStart = source.indexOf("{", interfaceIndex);
+  if (bodyStart === -1) return [];
+
+  let depth = 0;
+  let bodyEnd = bodyStart;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  const body = source.slice(bodyStart + 1, bodyEnd);
+  return [...body.matchAll(/^\s{2}([A-Za-z][A-Za-z0-9]*)\??:/gm)].map((match) => match[1]);
+}
 
 async function mustExist(path) {
   try {
@@ -106,6 +130,13 @@ for (const component of componentCatalog) {
     }
   }
 
+  const propDocNames = new Set(getComponentPropDocs(component).map((propDoc) => propDoc.name));
+  for (const prop of component.props) {
+    if (!propDocNames.has(prop)) {
+      failures.push(`${component.name} prop 문서에 catalog prop이 없습니다. / ${component.name} prop docs are missing catalog prop: ${prop}`);
+    }
+  }
+
   const componentDir = join(
     rootDir,
     "packages",
@@ -120,6 +151,14 @@ for (const component of componentCatalog) {
   await mustExist(join(componentDir, "README.md"));
   await mustExist(join(componentDir, "spec.md"));
   await mustExist(join(componentDir, "index.ts"));
+}
+
+for (const [componentName, propDocs] of Object.entries(componentPropDocs)) {
+  for (const propDoc of propDocs) {
+    if (!propDoc.description.includes(" / ")) {
+      failures.push(`${componentName}.${propDoc.name} prop 설명은 한글 우선/영문 병기를 유지해야 합니다. / ${componentName}.${propDoc.name} prop description must keep Korean-first English-paired writing.`);
+    }
+  }
 }
 
 const tokensPath = join(rootDir, "packages", "tokens", "src", "tokens.css");
@@ -156,6 +195,7 @@ for (const exportName of requiredExports) {
 
   const componentSource = await readFile(componentFile, "utf8").catch(() => "");
   const entrySource = await readFile(entryFile, "utf8").catch(() => "");
+  const readmeSource = await readFile(join(rootDir, "packages", "ui", "src", "components", category, slug, "README.md"), "utf8").catch(() => "");
 
   if (!componentSource.includes(`export function ${exportName}`) && !componentSource.includes(`export const ${exportName}`)) {
     failures.push(`${exportName} 구현은 자기 폴더의 ${slug}.tsx에서 named export여야 합니다. / ${exportName} implementation must be a named export in its own ${slug}.tsx file.`);
@@ -165,6 +205,19 @@ for (const exportName of requiredExports) {
   }
   if (!indexTs.includes(exportName)) {
     failures.push(`index.ts에서 컴포넌트를 export해야 합니다. / index.ts must export component: ${exportName}`);
+  }
+
+  if (componentPropDocs[exportName]) {
+    const documentedProps = new Set(componentPropDocs[exportName].map((propDoc) => propDoc.name));
+    const sourceProps = extractInterfacePropNames(componentSource, `${exportName}Props`);
+    for (const sourceProp of sourceProps) {
+      if (!documentedProps.has(sourceProp)) {
+        failures.push(`${exportName} prop table에 source prop이 없습니다. / ${exportName} prop table is missing source prop: ${sourceProp}`);
+      }
+    }
+    if (!readmeSource.includes("## Prop 표 / Prop Table") || !readmeSource.includes(propTableHeader)) {
+      failures.push(`${exportName} README에 Prop 표가 없습니다. / ${exportName} README is missing a prop table.`);
+    }
   }
 }
 


### PR DESCRIPTION
## 요약 / Summary
- `prop-docs.ts`에 prop-heavy component용 prop table metadata를 추가했습니다. / Added prop table metadata for prop-heavy components in `prop-docs.ts`.
- `DataGrid`, `Combobox`, `CommandPalette` README/spec에 catalog/source 기준 prop table을 반영했습니다. / Added catalog/source-aligned prop tables to `DataGrid`, `Combobox`, and `CommandPalette` README/spec files.
- scaffold가 기존 README/spec를 기본 보존하고 `--force-docs`에서만 문서 overwrite를 허용하도록 조정했습니다. / Adjusted the scaffold to preserve existing README/spec files by default and allow doc overwrites only with `--force-docs`.
- `components:validate`가 target source props, prop table, 한글 우선/영문 병기 설명을 검증하도록 보강했습니다. / Strengthened `components:validate` to check target source props, prop tables, and Korean-first English-paired descriptions.

## 검증 / Validation
- `npm run components:scaffold`
- `npm run components:validate`
- `npm run lint`
- `npm run typecheck`
- `npm run test:types`
- `npm run test`
- `git diff --check`

Closes #21
