### PR TITLE
[codex] Document DataGrid virtual scroll scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ All notable changes are documented in this file.
 - review/issue 운영 문서에 priority SLA, milestone 기준, follow-up 연결 규칙을 보강했습니다. / Strengthened review and issue operations docs with priority SLA, milestone criteria, and follow-up linking rules.
 - DataGrid 문서와 catalog prop 목록을 실제 상호작용 API에 맞췄습니다. / Aligned DataGrid docs and catalog prop lists with the actual interaction APIs.
 - scaffold가 기존 README/spec를 기본적으로 보존하고 `--force-docs`에서만 문서를 재생성하도록 바꿨습니다. / Changed scaffold behavior so existing README/spec files are preserved by default and regenerated only with `--force-docs`.
+- DataGrid virtual scroll을 v0.1 non-goal로 정하고 row count, 성능, 접근성 검토 기준을 문서화했습니다. / Defined DataGrid virtual scroll as a v0.1 non-goal and documented row-count, performance, and accessibility criteria.

--- a/docs/component-roadmap.md
+++ b/docs/component-roadmap.md
@@ -64,7 +64,7 @@ External references are based on accessibility patterns and component operating 
 | Forms | FileUploader | 파일 선택과 첨부 상태 기준입니다. / Baseline for file selection and attachment state. |
 | Layout | Divider | 카드 남용 없이 구획을 나누는 최소 단위입니다. / Minimal separator that avoids overusing cards. |
 | Data Display | Table | 레코드 비교와 운영형 화면의 핵심입니다. / Core pattern for comparing records and building operational screens. |
-| Data Display | DataGrid | sorting, selection, row action이 필요한 dense grid 기준입니다. / Baseline for dense grids that need sorting, selection, and row actions. |
+| Data Display | DataGrid | sorting, selection, row action이 필요한 dense grid 기준이며 virtual scroll은 v0.1 non-goal입니다. / Baseline for dense grids that need sorting, selection, and row actions; virtual scroll is a v0.1 non-goal. |
 | Data Display | EmptyState | 빈 화면의 next action을 표준화합니다. / Standardizes next actions for empty screens. |
 | Data Display | List | 반복 데이터의 기본 표시 단위입니다. / Base display unit for repeated data. |
 

--- a/docs/datagrid-virtual-scroll.md
+++ b/docs/datagrid-virtual-scroll.md
@@ -1,0 +1,45 @@
+# DataGrid 가상 스크롤 결정 / DataGrid Virtual Scroll Decision
+
+DataGrid의 virtual scroll은 현재 `@workspace/ui` v0.1 범위에 포함하지 않습니다.
+DataGrid virtual scroll is not included in the current `@workspace/ui` v0.1 scope.
+
+## 결정 / Decision
+
+- 현재 DataGrid는 500 row 이하의 조작형 table/grid를 기준으로 유지합니다. / The current DataGrid targets interactive table/grid use cases with up to 500 rows.
+- 501-2,000 row는 우선 pagination, server filtering, column pruning으로 해결합니다. / For 501-2,000 rows, prefer pagination, server filtering, and column pruning first.
+- 2,000 row를 넘거나 한 화면에서 지속적인 scroll 조작이 핵심 workflow가 되면 별도 virtualization proposal을 엽니다. / Open a separate virtualization proposal when row count exceeds 2,000 or continuous scrolling becomes a core workflow.
+- v0.1에서는 `virtualized`, `rowHeight`, `overscan`, `estimatedRowHeight` prop을 추가하지 않습니다. / v0.1 does not add `virtualized`, `rowHeight`, `overscan`, or `estimatedRowHeight` props.
+
+## 성능 목표 / Performance Goals
+
+virtualization을 도입하려면 아래 목표를 먼저 충족해야 합니다.
+Virtualization must meet the goals below before adoption.
+
+- 초기 render는 1,000 row dataset 기준 200ms 이하를 목표로 합니다. / Initial render should target 200ms or less for a 1,000-row dataset.
+- scroll 중 main thread 긴 task는 50ms를 넘지 않도록 설계합니다. / Long main-thread tasks during scroll should stay below 50ms.
+- keyboard row navigation은 focus 이동 후 100ms 안에 시각 focus와 `aria-activedescendant` 또는 roving `tabIndex`가 동기화되어야 합니다. / Keyboard row navigation must sync visual focus and `aria-activedescendant` or roving `tabIndex` within 100ms after focus movement.
+- DOM에 유지되는 row 수는 viewport row + overscan으로 제한하되 selection, active row, focus return state는 rowKey로 보존해야 합니다. / DOM rows should be limited to viewport rows plus overscan, while selection, active row, and focus return state must be preserved by rowKey.
+
+## 접근성 영향 / Accessibility Impact
+
+- native table처럼 모든 row가 DOM에 있는 구조가 아니므로 `aria-rowcount`, `aria-rowindex`, `aria-colcount`를 정확히 계산해야 합니다. / Because not every row stays in the DOM like a native table, `aria-rowcount`, `aria-rowindex`, and `aria-colcount` must be calculated accurately.
+- screen reader가 현재 window를 이해하도록 “현재 101-140행 / 전체 2,400행” 같은 visible text 또는 live region 전략을 검토합니다. / Review visible text or live-region announcements such as “Rows 101-140 of 2,400” so screen readers understand the current window.
+- focused row가 unmount될 수 있으므로 roving `tabIndex`만으로는 부족할 수 있습니다. `aria-activedescendant` 기반 focus proxy가 필요한지 검토합니다. / Because a focused row can unmount, roving `tabIndex` may not be enough. Review whether an `aria-activedescendant` focus proxy is required.
+- column resize, sticky header, selection checkbox가 virtualized body와 분리될 때 DOM order와 visual order가 어긋나지 않아야 합니다. / DOM order and visual order must remain aligned when column resize, sticky header, and selection checkboxes are separated from a virtualized body.
+- browser zoom, reduced motion, high contrast, forced colors에서도 row position과 focus ring이 유지되어야 합니다. / Row position and focus ring must remain stable under browser zoom, reduced motion, high contrast, and forced colors.
+
+## Docs App 예시 결정 / Docs App Example Decision
+
+- 현재 docs app에는 virtualized example을 추가하지 않습니다. / The current docs app does not add a virtualized example.
+- 구현이 없는 prop을 문서 예시로 보여주면 consumer가 사용 가능한 API로 오해할 수 있으므로 non-goal만 명시합니다. / Showing an unimplemented prop in docs examples could make consumers believe the API is available, so the docs only state the non-goal.
+- future proposal이 열리면 docs app에는 1,000 row fixture, keyboard navigation, screen reader announcement, scroll performance smoke를 함께 추가합니다. / When a future proposal opens, the docs app should add a 1,000-row fixture, keyboard navigation, screen reader announcements, and scroll performance smoke together.
+
+## 후속 조건 / Follow-up Conditions
+
+다음 조건 중 하나가 실제 project 요구로 확인되면 새 issue를 엽니다.
+Open a new issue when one of the following conditions appears in a real project requirement.
+
+- 한 화면에서 2,000 row 이상을 pagination 없이 탐색해야 합니다. / A screen must browse more than 2,000 rows without pagination.
+- server filtering으로도 첫 interaction까지의 시간이 500ms를 넘습니다. / Time to first interaction exceeds 500ms even with server filtering.
+- row height가 일정하고 custom cell editor보다 scan/selection이 핵심입니다. / Row height is stable, and scanning/selection matters more than custom cell editing.
+- accessibility owner가 virtualized grid announcement 전략을 review할 수 있습니다. / An accessibility owner can review the virtualized grid announcement strategy.

--- a/packages/ui/src/components/data-display/data-grid/README.md
+++ b/packages/ui/src/components/data-display/data-grid/README.md
@@ -101,3 +101,10 @@ export function Example() {
 - controlled/uncontrolled 값이 있는 경우 `onValueChange`, `onOpenChange`, `onSelectionChange`처럼 `onPascalCase` event prop을 사용합니다. / Controlled or uncontrolled values use `onPascalCase` event props such as `onValueChange`, `onOpenChange`, and `onSelectionChange`.
 - hover, active, selected, disabled는 shared state token과 `data-*` hook으로 표현합니다. / Hover, active, selected, and disabled are represented with shared state tokens and `data-*` hooks.
 - virtual scroll은 이번 범위에서 제외하고, large data가 실제 요구될 때 별도 이슈로 설계합니다. / Virtual scroll is excluded from this scope and should be designed in a separate issue when large data is a real requirement.
+
+## 가상 스크롤 범위 / Virtual Scroll Scope
+
+- v0.1에서는 virtual scroll을 구현하지 않고 500 row 이하의 조작형 grid를 기준으로 유지합니다. / v0.1 does not implement virtual scroll and keeps the target at interactive grids with up to 500 rows.
+- 501-2,000 row는 pagination, server filtering, column pruning을 우선합니다. / For 501-2,000 rows, prefer pagination, server filtering, and column pruning first.
+- `virtualized`, `rowHeight`, `overscan`, `estimatedRowHeight` prop은 아직 public API가 아닙니다. / `virtualized`, `rowHeight`, `overscan`, and `estimatedRowHeight` are not public APIs yet.
+- 자세한 기준은 [DataGrid 가상 스크롤 결정](../../../../../../docs/datagrid-virtual-scroll.md)을 따릅니다. / Follow [DataGrid Virtual Scroll Decision](../../../../../../docs/datagrid-virtual-scroll.md) for detailed criteria.

--- a/packages/ui/src/components/data-display/data-grid/spec.md
+++ b/packages/ui/src/components/data-display/data-grid/spec.md
@@ -99,4 +99,5 @@
 
 - 이 컴포넌트는 `table with grid-like interactions` primitive를 기준으로 구현합니다. / This component is implemented around the `table with grid-like interactions` primitive.
 - public API는 catalog의 props 목록을 기준으로 유지하고 breaking change는 release note에 기록합니다. / The public API follows the catalog prop list, and breaking changes are recorded in release notes.
-- virtual scroll은 현재 범위에서 제외하고, 실제 large dataset 요구가 생기면 별도 이슈로 성능 기준과 ARIA 영향을 함께 설계합니다. / Virtual scroll is excluded from the current scope; when large dataset requirements appear, a separate issue should define performance criteria and ARIA impact together.
+- virtual scroll은 v0.1 non-goal입니다. 500 row 이하를 현재 기준으로 두고, 2,000 row 초과 또는 continuous scroll workflow가 실제 요구될 때 별도 proposal을 엽니다. / Virtual scroll is a v0.1 non-goal. The current target is up to 500 rows, and a separate proposal opens when real requirements exceed 2,000 rows or need continuous scrolling.
+- virtual scroll proposal은 `aria-rowcount`, `aria-rowindex`, focus proxy, screen reader announcement, scroll performance smoke를 함께 포함해야 합니다. / A virtual scroll proposal must include `aria-rowcount`, `aria-rowindex`, focus proxy, screen reader announcement, and scroll performance smoke together.


### PR DESCRIPTION
## 요약 / Summary
- DataGrid virtual scroll을 v0.1 non-goal로 결정하고 별도 결정 문서를 추가했습니다. / Defined DataGrid virtual scroll as a v0.1 non-goal and added a dedicated decision document.
- row count 기준, performance 목표, ARIA/table semantics 영향, screen reader announcement 검토 기준을 정리했습니다. / Documented row-count thresholds, performance goals, ARIA/table semantics impact, and screen reader announcement criteria.
- docs app에는 구현 없는 virtualized example을 추가하지 않기로 결정했습니다. / Decided not to add a docs app virtualized example without an implementation.
- DataGrid README/spec와 roadmap에 non-goal과 future proposal 조건을 반영했습니다. / Reflected the non-goal and future proposal conditions in DataGrid README/spec and the roadmap.

## 검증 / Validation
- `npm run lint`
- `npm run components:validate`
- `npm --workspace @workspace/docs run build`
- `git diff --check`

Closes #12
