### PR TITLE
[codex] Add markdown link validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Lint와 format 검증 / Lint and format checks
         run: npm run lint
 
+      - name: Markdown 내부 링크 검증 / Markdown internal link checks
+        run: npm run docs:links
+
       - name: 컴포넌트 검증 / Component validation
         run: npm run test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes are documented in this file.
 - lint/format 최소 품질 게이트 `npm run lint`를 추가했습니다. / Added the minimal lint/format quality gate `npm run lint`.
 - docs app responsive, theme switch, Tab focus browser smoke 검증 `test:docs-smoke`를 추가했습니다. / Added `test:docs-smoke` browser smoke validation for docs app responsive layout, theme switching, and Tab focus.
 - prop-heavy component README/spec용 prop table metadata와 검증을 추가했습니다. / Added prop table metadata and validation for prop-heavy component README/spec docs.
+- repo 내부 Markdown 상대 링크 검증 `docs:links`를 추가했습니다. / Added `docs:links` validation for repo-internal Markdown relative links.
 
 ### Changed
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -12,6 +12,7 @@ This document explains the minimum lint/format criteria used in CI.
 - CSS: CRLF, trailing whitespace, tab indentation, merge conflict marker, missing final newline을 검사합니다. / CSS checks CRLF, trailing whitespace, tab indentation, merge conflict markers, and missing final newlines.
 - Markdown: CRLF, trailing whitespace, merge conflict marker, missing final newline을 검사합니다. / Markdown checks CRLF, trailing whitespace, merge conflict markers, and missing final newlines.
 - JSON/YAML: CRLF, trailing whitespace, tab indentation, merge conflict marker, missing final newline을 검사합니다. / JSON/YAML checks CRLF, trailing whitespace, tab indentation, merge conflict markers, and missing final newlines.
+- `npm run docs:links`: repo 내부 Markdown 상대 링크 대상이 실제로 존재하는지 검사합니다. / `npm run docs:links` checks that repo-internal Markdown relative link targets actually exist.
 
 ## 실패 메시지 / Failure Messages
 
@@ -20,6 +21,7 @@ Failure messages are printed as `file:line: Korean explanation / English explana
 
 ```bash
 npm run lint
+npm run docs:links
 ```
 
 ## 단계적 확장 / Phased Expansion

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "npm --workspace @workspace/ui run build",
     "dev": "npm --workspace @workspace/docs run dev",
     "docs:dev": "npm --workspace @workspace/docs run dev",
+    "docs:links": "node scripts/verify-markdown-links.mjs",
     "lint": "node scripts/verify-quality-gates.mjs",
     "test": "npm run components:validate && npm run build && tsx scripts/accessibility-smoke.mjs && tsx scripts/interaction-a11y.mjs && tsx scripts/verify-package-exports.mjs",
     "test:a11y": "npm run build && tsx scripts/accessibility-smoke.mjs",
@@ -25,7 +26,7 @@
     "test:visual": "node scripts/visual-regression.mjs",
     "release:verify": "node scripts/verify-release.mjs",
     "release:prepare": "node scripts/prepare-release.mjs",
-    "release:dry-run": "npm run lint && npm run test && npm run typecheck && npm --workspace @workspace/docs run build && npm run test:consumer && npm run test:tokens && npm run test:types && npm run test:docs-smoke && npm run test:visual && npm run release:verify && npm pack --workspace @workspace/ui --dry-run",
+    "release:dry-run": "npm run lint && npm run docs:links && npm run test && npm run typecheck && npm --workspace @workspace/docs run build && npm run test:consumer && npm run test:tokens && npm run test:types && npm run test:docs-smoke && npm run test:visual && npm run release:verify && npm pack --workspace @workspace/ui --dry-run",
     "typecheck": "npm --workspace @workspace/ui run typecheck && npm --workspace @workspace/docs run typecheck && npm --workspace @workspace/consumer-fixture run typecheck"
   },
   "dependencies": {

--- a/scripts/verify-markdown-links.mjs
+++ b/scripts/verify-markdown-links.mjs
@@ -1,0 +1,113 @@
+import { access, readdir, readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const ignoredDirectories = new Set([".git", "node_modules", "dist", "artifacts", "coverage"]);
+const failures = [];
+
+async function collectMarkdownFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (ignoredDirectories.has(entry.name)) continue;
+      files.push(...await collectMarkdownFiles(join(directory, entry.name)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(join(directory, entry.name));
+    }
+  }
+  return files;
+}
+
+function isSkippedTarget(target) {
+  return target === "" || target.startsWith("#") || /^[a-z][a-z0-9+.-]*:/i.test(target);
+}
+
+function normalizeTarget(rawTarget) {
+  const trimmedTarget = rawTarget.trim();
+  const targetWithoutTitle = trimmedTarget.startsWith("<")
+    ? trimmedTarget.replace(/^<([^>]+)>.*$/, "$1")
+    : trimmedTarget.split(/\s+/)[0];
+  const targetWithoutHash = targetWithoutTitle.split("#")[0];
+  try {
+    return decodeURIComponent(targetWithoutHash);
+  } catch {
+    return targetWithoutHash;
+  }
+}
+
+function extractMarkdownLinks(content) {
+  const links = [];
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] !== "[" || content[index - 1] === "!") continue;
+    const labelEnd = content.indexOf("](", index);
+    if (labelEnd === -1) continue;
+
+    let cursor = labelEnd + 2;
+    let depth = 1;
+    let target = "";
+    while (cursor < content.length && depth > 0) {
+      const character = content[cursor];
+      if (character === "(") depth += 1;
+      if (character === ")") depth -= 1;
+      if (depth > 0) target += character;
+      cursor += 1;
+    }
+
+    if (depth === 0) {
+      const line = content.slice(0, index).split("\n").length;
+      links.push({ line, target: target.trim() });
+      index = cursor - 1;
+    }
+  }
+  return links;
+}
+
+async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isInsideRoot(path) {
+  const relativePath = relative(rootDir, path);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+const markdownFiles = await collectMarkdownFiles(rootDir);
+
+for (const filePath of markdownFiles) {
+  const content = await readFile(filePath, "utf8");
+  const links = extractMarkdownLinks(content);
+  const relativeFilePath = relative(rootDir, filePath);
+
+  for (const link of links) {
+    if (isSkippedTarget(link.target)) continue;
+
+    const normalizedTarget = normalizeTarget(link.target);
+    if (isSkippedTarget(normalizedTarget)) continue;
+
+    const absoluteTarget = resolve(dirname(filePath), normalizedTarget);
+    if (!isInsideRoot(absoluteTarget)) {
+      failures.push(`${relativeFilePath}:${link.line}: repo 밖 Markdown link는 허용하지 않습니다. / Markdown link target outside the repo is not allowed: ${link.target}`);
+      continue;
+    }
+
+    if (!await pathExists(absoluteTarget)) {
+      failures.push(`${relativeFilePath}:${link.line}: Markdown link 대상이 없습니다. / Markdown link target does not exist: ${link.target}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+
+console.log(`Markdown 내부 링크 검증 완료: ${markdownFiles.length}개 파일. / Markdown internal links passed: ${markdownFiles.length} files.`);


### PR DESCRIPTION
## 요약 / Summary
- repo 내부 Markdown 상대 링크 대상 존재 여부를 확인하는 `docs:links` 검증을 추가했습니다. / Added `docs:links` validation for repo-internal Markdown relative link targets.
- 외부 URL, scheme link, anchor-only link는 네트워크 의존 없이 제외합니다. / Excludes external URLs, scheme links, and anchor-only links without network dependency.
- CI와 `release:dry-run`에 Markdown link 검증을 연결했습니다. / Wired Markdown link validation into CI and `release:dry-run`.
- quality gate 문서와 changelog를 갱신했습니다. / Updated quality gate docs and changelog.

## 검증 / Validation
- `npm run docs:links`
- `npm run lint`
- `npm run test`
- `npm --workspace @workspace/docs run build`
- `git diff --check`

Closes #42
