### PR TITLE
[codex] Add natural tab smoke for docs app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes are documented in this file.
 - docs app responsive, theme switch, Tab focus browser smoke 검증 `test:docs-smoke`를 추가했습니다. / Added `test:docs-smoke` browser smoke validation for docs app responsive layout, theme switching, and Tab focus.
 - prop-heavy component README/spec용 prop table metadata와 검증을 추가했습니다. / Added prop table metadata and validation for prop-heavy component README/spec docs.
 - repo 내부 Markdown 상대 링크 검증 `docs:links`를 추가했습니다. / Added `docs:links` validation for repo-internal Markdown relative links.
+- docs app skip link와 자연 Tab 진입 browser smoke 검증을 추가했습니다. / Added docs app skip link and natural Tab entry browser smoke validation.
 
 ### Changed
 
@@ -28,3 +29,5 @@ All notable changes are documented in this file.
 - DataGrid 문서와 catalog prop 목록을 실제 상호작용 API에 맞췄습니다. / Aligned DataGrid docs and catalog prop lists with the actual interaction APIs.
 - scaffold가 기존 README/spec를 기본적으로 보존하고 `--force-docs`에서만 문서를 재생성하도록 바꿨습니다. / Changed scaffold behavior so existing README/spec files are preserved by default and regenerated only with `--force-docs`.
 - DataGrid virtual scroll을 v0.1 non-goal로 정하고 row count, 성능, 접근성 검토 기준을 문서화했습니다. / Defined DataGrid virtual scroll as a v0.1 non-goal and documented row-count, performance, and accessibility criteria.
+- CommandPalette input focus가 닫힌 dialog에서 초기 page focus를 훔치지 않도록 조정했습니다. / Adjusted CommandPalette input focus so a closed dialog does not steal initial page focus.
+- overlay focus return이 실제로 기억한 focus가 있을 때만 복원되도록 수정했습니다. / Fixed overlay focus return so it restores focus only when remembered focus exists.

--- a/apps/docs/src/main.tsx
+++ b/apps/docs/src/main.tsx
@@ -334,6 +334,7 @@ function App() {
       const targetId = decodeURIComponent(window.location.hash.replace("#", ""));
       const target = targetId ? document.getElementById(targetId) : null;
       target?.scrollIntoView({ block: "start" });
+      target?.focus({ preventScroll: true });
     };
 
     requestAnimationFrame(scrollToHash);
@@ -360,6 +361,20 @@ function App() {
 
   return (
     <div className="shell" data-ds-theme={activeTheme}>
+      <a
+        className="skip-link"
+        href="#main-content"
+        onClick={(event) => {
+          const target = document.getElementById("main-content");
+          if (!target) return;
+          event.preventDefault();
+          window.history.replaceState(null, "", "#main-content");
+          target.focus();
+          target.scrollIntoView({ block: "start" });
+        }}
+      >
+        본문으로 이동 / Skip to content
+      </a>
       <aside className="sidebar" aria-label="문서 메뉴 / Documentation menu">
         <div className="brand">
           <span className="brand-mark" aria-hidden="true">DS</span>
@@ -373,7 +388,7 @@ function App() {
         </nav>
       </aside>
 
-      <main className="content">
+      <main className="content" id="main-content" tabIndex={-1}>
         <section className="intro" aria-labelledby="page-title">
           <div className="intro-main">
             <p className="eyebrow">React 컴포넌트 카탈로그 / React component catalog</p>
@@ -742,7 +757,7 @@ function App() {
 
 function Section({ id, eyebrow, title, children }: { id: string; eyebrow: string; title: string; children: ReactNode }) {
   return (
-    <section className="section" id={id} aria-labelledby={`${id}-title`}>
+    <section className="section" id={id} tabIndex={-1} aria-labelledby={`${id}-title`}>
       <div className="section-heading">
         <p className="eyebrow">{eyebrow}</p>
         <h2 id={`${id}-title`}>{title}</h2>

--- a/apps/docs/styles.css
+++ b/apps/docs/styles.css
@@ -48,6 +48,29 @@ select {
   color: var(--text);
 }
 
+.skip-link {
+  position: fixed;
+  z-index: var(--ds-z-toast);
+  top: var(--ds-space-3);
+  left: var(--ds-space-3);
+  transform: translateY(calc(-100% - var(--ds-space-4)));
+  border: 1px solid var(--ds-color-action-primary-border);
+  border-radius: var(--ds-radius-6);
+  background: var(--ds-color-action-primary-bg);
+  color: var(--ds-color-action-primary-fg);
+  padding: var(--ds-space-2) var(--ds-space-4);
+  font-size: var(--ds-font-size-14);
+  font-weight: 800;
+  text-decoration: none;
+  transition: transform var(--ds-motion-duration-fast) var(--ds-motion-easing-standard);
+}
+
+.skip-link:focus-visible {
+  outline: none;
+  transform: translateY(0);
+  box-shadow: var(--ds-focus-ring);
+}
+
 .sidebar {
   position: sticky;
   top: 0;

--- a/docs/responsive-qa.md
+++ b/docs/responsive-qa.md
@@ -30,3 +30,4 @@ npm run test:docs-smoke
 - header, theme controls, responsive matrix, component preview가 viewport 밖으로 밀리거나 sibling overlap을 만들면 실패합니다. / It fails when the header, theme controls, responsive matrix, or component preview leaves the viewport or creates sibling overlap.
 - DARK/NORMAL theme switch가 `data-ds-theme`와 computed background를 바꾸는지 확인합니다. / It verifies that DARK/NORMAL theme switching updates `data-ds-theme` and computed background.
 - 첫 Tab focus 흐름이 보이지 않는 요소나 viewport 밖 요소로 이동하지 않는지 최소 검증합니다. / It minimally verifies that the first Tab focus flow does not move to invisible or out-of-viewport elements.
+- body에서 첫 Tab은 visible skip link로 진입하고 Enter는 main content focus로 이동해야 합니다. hash route에서는 target section을 focus anchor로 잡고 다음 Tab이 visible focus로 이동해야 합니다. / From body, the first Tab must enter a visible skip link, and Enter must move focus to main content. On hash routes, the target section acts as the focus anchor and the next Tab must move to visible focus.

--- a/packages/ui/src/components/overlays/command-palette/command-palette.tsx
+++ b/packages/ui/src/components/overlays/command-palette/command-palette.tsx
@@ -41,6 +41,7 @@ export function CommandPalette({
   ...props
 }: CommandPaletteProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { triggerRef, rememberFocus, restoreFocus } = useFocusReturn<HTMLButtonElement>();
   const titleId = useId();
   const listId = useId();
@@ -66,6 +67,7 @@ export function CommandPalette({
     if (currentOpen && !dialog.open) {
       rememberFocus();
       dialog.showModal();
+      window.requestAnimationFrame(() => inputRef.current?.focus());
     }
     if (!currentOpen && dialog.open) dialog.close();
   }, [currentOpen, rememberFocus]);
@@ -118,11 +120,11 @@ export function CommandPalette({
         </div>
         <input
           className="ds-CommandPalette-input"
+          ref={inputRef}
           aria-activedescendant={activeCommandId}
           aria-autocomplete="list"
           aria-controls={listId}
           aria-expanded={currentOpen}
-          autoFocus
           placeholder={placeholder}
           role="combobox"
           value={query}

--- a/packages/ui/src/components/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu/dropdown-menu.tsx
@@ -29,7 +29,7 @@ export function DropdownMenu({ triggerLabel = "메뉴 / Menu", items = [], open,
   const rootRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuId = useId();
-  const { triggerRef, restoreFocus } = useFocusReturn<HTMLButtonElement>();
+  const { triggerRef, rememberFocus, restoreFocus } = useFocusReturn<HTMLButtonElement>();
   const closeMenu = useCallback((returnFocus = true) => {
     setOpen(false);
     if (returnFocus) restoreFocus();
@@ -79,7 +79,18 @@ export function DropdownMenu({ triggerLabel = "메뉴 / Menu", items = [], open,
 
   return (
     <div className={classNames("ds-DropdownMenu", className)} data-state={currentOpen ? "open" : "closed"} ref={rootRef} {...props}>
-      <Button ref={triggerRef} variant="outline" tone="neutral" aria-haspopup="menu" aria-expanded={currentOpen} aria-controls={menuId} onClick={() => setOpen((previousOpen) => !previousOpen)}>
+      <Button
+        ref={triggerRef}
+        variant="outline"
+        tone="neutral"
+        aria-haspopup="menu"
+        aria-expanded={currentOpen}
+        aria-controls={menuId}
+        onClick={() => setOpen((previousOpen) => {
+          if (!previousOpen) rememberFocus();
+          return !previousOpen;
+        })}
+      >
         {triggerLabel}
       </Button>
       <div className="ds-DropdownMenu-content" id={menuId} role="menu" data-placement={placement} data-state={currentOpen ? "open" : "closed"} hidden={!currentOpen} ref={menuRef} onKeyDown={onMenuKeyDown}>

--- a/packages/ui/src/components/overlays/popover/popover.tsx
+++ b/packages/ui/src/components/overlays/popover/popover.tsx
@@ -22,7 +22,7 @@ export function Popover({ triggerLabel = "열기 / Open", title, children, open,
   });
   const rootRef = useRef<HTMLDivElement>(null);
   const panelId = useId();
-  const { triggerRef, restoreFocus } = useFocusReturn<HTMLButtonElement>();
+  const { triggerRef, rememberFocus, restoreFocus } = useFocusReturn<HTMLButtonElement>();
   const closePopover = useCallback((returnFocus = true) => {
     setOpen(false);
     if (returnFocus) restoreFocus();
@@ -37,7 +37,17 @@ export function Popover({ triggerLabel = "열기 / Open", title, children, open,
 
   return (
     <div className={classNames("ds-Popover", className)} data-state={currentOpen ? "open" : "closed"} ref={rootRef} {...props}>
-      <Button ref={triggerRef} variant="outline" tone="neutral" aria-expanded={currentOpen} aria-controls={panelId} onClick={() => setOpen((previousOpen) => !previousOpen)}>
+      <Button
+        ref={triggerRef}
+        variant="outline"
+        tone="neutral"
+        aria-expanded={currentOpen}
+        aria-controls={panelId}
+        onClick={() => setOpen((previousOpen) => {
+          if (!previousOpen) rememberFocus();
+          return !previousOpen;
+        })}
+      >
         {triggerLabel}
       </Button>
       <div className="ds-Popover-panel" id={panelId} data-placement={placement} data-state={currentOpen ? "open" : "closed"} hidden={!currentOpen}>

--- a/packages/ui/src/shared/use-focus-return.ts
+++ b/packages/ui/src/shared/use-focus-return.ts
@@ -9,7 +9,7 @@ export function useFocusReturn<T extends HTMLElement = HTMLElement>() {
   }, []);
 
   const restoreFocus = useCallback(() => {
-    const target = triggerRef.current ?? fallbackRef.current;
+    const target = fallbackRef.current;
     fallbackRef.current = null;
     window.setTimeout(() => target?.focus(), 0);
   }, []);

--- a/scripts/docs-browser-smoke.mjs
+++ b/scripts/docs-browser-smoke.mjs
@@ -165,6 +165,79 @@ async function assertThemeSwitch(page) {
   await page.waitForFunction(() => document.documentElement.dataset.dsTheme === "normal");
 }
 
+async function getFocusedElementState(page) {
+  return page.evaluate(() => {
+    const element = document.activeElement;
+    if (!(element instanceof HTMLElement)) return { label: "", tagName: "", visible: false, withinViewport: false };
+    const rect = element.getBoundingClientRect();
+    const style = window.getComputedStyle(element);
+    return {
+      label: element.textContent?.trim().replace(/\s+/g, " ").slice(0, 80) || element.getAttribute("aria-label") || "",
+      rect: {
+        bottom: Math.round(rect.bottom),
+        left: Math.round(rect.left),
+        right: Math.round(rect.right),
+        top: Math.round(rect.top)
+      },
+      tagName: element.tagName,
+      visible: rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none",
+      withinViewport: rect.top >= -4 && rect.left >= -4 && rect.bottom <= window.innerHeight + 4 && rect.right <= window.innerWidth + 4
+    };
+  });
+}
+
+async function assertNaturalTabEntry(browser) {
+  const focusContext = await browser.newContext();
+
+  try {
+    for (const url of [`${baseUrl}/`, `${baseUrl}/#components`]) {
+      const focusPage = await focusContext.newPage();
+      focusPage.setDefaultTimeout(pageTimeout);
+      focusPage.setDefaultNavigationTimeout(pageTimeout);
+      await focusPage.setViewportSize({ width: 1440, height: 960 });
+      await focusPage.goto(url, { waitUntil: "domcontentloaded", timeout: pageTimeout });
+      await focusPage.waitForLoadState("networkidle", { timeout: 1_000 }).catch(() => undefined);
+
+      if (url.includes("#components")) {
+        await focusPage.waitForFunction(() => document.activeElement?.id === "components");
+        await focusPage.waitForFunction(() => {
+          const target = document.getElementById("components");
+          const rect = target?.getBoundingClientRect();
+          return rect && rect.top >= -4 && rect.top <= 120;
+        });
+        await focusPage.keyboard.press("Tab");
+        await focusPage.waitForTimeout(120);
+        const hashFocus = await getFocusedElementState(focusPage);
+        if (!hashFocus.visible || !hashFocus.withinViewport) {
+          failures.push(`natural tab: hash route 이후 Tab이 visible focus로 이동하지 않았습니다. / Tab after hash route did not move to visible focus: ${JSON.stringify({ hashFocus, url })}`);
+        }
+        await focusPage.close();
+        continue;
+      }
+
+      await focusPage.keyboard.press("Tab");
+      await focusPage.waitForTimeout(120);
+
+      const firstFocus = await getFocusedElementState(focusPage);
+      const isSkipLink = firstFocus.label.includes("본문으로 이동") || firstFocus.label.includes("Skip to content");
+      if (!isSkipLink || !firstFocus.visible || !firstFocus.withinViewport) {
+        failures.push(`natural tab: 첫 Tab이 visible skip link로 이동하지 않았습니다. / First Tab did not move to a visible skip link: ${JSON.stringify({ firstFocus, url })}`);
+      }
+
+      await focusPage.keyboard.press("Enter");
+      await focusPage.waitForTimeout(100);
+      const skippedFocus = await getFocusedElementState(focusPage);
+      const mainTopVisible = skippedFocus.rect && skippedFocus.rect.top >= -4 && skippedFocus.rect.top <= 4;
+      if (skippedFocus.tagName !== "MAIN" || !skippedFocus.visible || !mainTopVisible) {
+        failures.push(`natural tab: skip link가 main content focus로 이동하지 않았습니다. / Skip link did not move focus to main content: ${JSON.stringify({ skippedFocus, url })}`);
+      }
+      await focusPage.close();
+    }
+  } finally {
+    await focusContext.close();
+  }
+}
+
 async function assertTabFocus(browser) {
   const focusContext = await browser.newContext();
   const focusPage = await focusContext.newPage();
@@ -182,24 +255,7 @@ async function assertTabFocus(browser) {
         await focusPage.keyboard.press("Tab");
         await focusPage.waitForTimeout(50);
       }
-      focusSteps.push(await focusPage.evaluate(() => {
-        const element = document.activeElement;
-        if (!(element instanceof HTMLElement)) return { label: "", tagName: "", visible: false };
-        const rect = element.getBoundingClientRect();
-        const style = window.getComputedStyle(element);
-        return {
-          label: element.textContent?.trim().replace(/\s+/g, " ").slice(0, 80) || element.getAttribute("aria-label") || "",
-          rect: {
-            bottom: Math.round(rect.bottom),
-            left: Math.round(rect.left),
-            right: Math.round(rect.right),
-            top: Math.round(rect.top)
-          },
-          tagName: element.tagName,
-          visible: rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none",
-          withinViewport: rect.top >= -4 && rect.left >= -4 && rect.bottom <= window.innerHeight + 4 && rect.right <= window.innerWidth + 4
-        };
-      }));
+      focusSteps.push(await getFocusedElementState(focusPage));
     }
   } finally {
     await focusContext.close();
@@ -234,6 +290,7 @@ try {
   }
 
   await assertThemeSwitch(page);
+  await assertNaturalTabEntry(browser);
   await assertTabFocus(browser);
 } finally {
   await browser?.close();


### PR DESCRIPTION
## 요약 / Summary
- docs app에 visible skip link와 `main` focus target을 추가했습니다. / Added a visible skip link and `main` focus target to the docs app.
- hash route 진입 시 target section을 focus anchor로 잡아 긴 문서 scroll 상태에서도 Tab 순서를 안정화했습니다. / Stabilized Tab order on long-document hash routes by focusing the target section as an anchor.
- `test:docs-smoke`가 body 첫 Tab, skip link activation, hash route 이후 visible focus를 검증하도록 확장했습니다. / Expanded `test:docs-smoke` to verify first Tab from body, skip link activation, and visible focus after hash routes.
- 닫힌 CommandPalette/dialog 계열 overlay가 초기 page focus를 훔치지 않도록 focus return 흐름을 정리했습니다. / Cleaned up focus-return flow so closed CommandPalette/dialog-style overlays do not steal initial page focus.

## 검증 / Validation
- `npm run lint`
- `npm run docs:links`
- `npm run typecheck`
- `npm run test`
- `npm run test:docs-smoke`
- `npm --workspace @workspace/docs run build`
- `npm run test:visual`
- `git diff --check`

Closes #39
