### PR TITLE
[codex] Add component docs regeneration guard

### DIFF
--- a/docs/component-authoring.md
+++ b/docs/component-authoring.md
@@ -43,7 +43,9 @@ Every component documents the items below before implementation.
 - 상세 prop table은 `packages/ui/src/components/prop-docs.ts`에서 관리하고 scaffold가 `Prop 표 / Prop Table`로 렌더링합니다. / Detailed prop tables are managed in `packages/ui/src/components/prop-docs.ts` and rendered by the scaffold as `Prop Table`.
 - 기존 README/spec의 다른 내용을 보존하면서 prop table만 동기화할 때는 `npm run components:props`를 사용합니다. / Use `npm run components:props` when only prop tables should be synced while preserving the rest of existing README/spec files.
 - `DataGrid`, `Combobox`, `CommandPalette`처럼 prop이 많은 컴포넌트는 source props와 prop table이 `npm run components:validate`에서 함께 검증됩니다. / Prop-heavy components such as `DataGrid`, `Combobox`, and `CommandPalette` validate source props and prop tables together through `npm run components:validate`.
-- 기존 README/spec는 기본적으로 보존됩니다. 강제로 문서를 재생성해야 할 때만 사용자 수동 변경 여부를 확인한 뒤 `npm run components:scaffold -- --force-docs`를 사용합니다. / Existing README/spec files are preserved by default. Use `npm run components:scaffold -- --force-docs` only after checking for user-authored manual changes.
+- 기존 README/spec는 기본적으로 보존됩니다. 강제로 문서를 재생성해야 할 때는 먼저 `npm run components:scaffold -- --force-docs --dry-run`으로 변경될 파일과 이유를 확인한 뒤 `npm run components:scaffold -- --force-docs`를 사용합니다. / Existing README/spec files are preserved by default. When docs must be regenerated, first inspect changed files and reasons with `npm run components:scaffold -- --force-docs --dry-run`, then run `npm run components:scaffold -- --force-docs`.
+- 수동 작성 내용을 보존해야 하는 문서는 `<!-- ds-manual-start -->`와 `<!-- ds-manual-end -->` 사이에 둡니다. scaffold는 `--force-docs` 실행 시 이 구간을 유지합니다. / Put user-authored content that must be preserved between `<!-- ds-manual-start -->` and `<!-- ds-manual-end -->`. The scaffold keeps this block during `--force-docs`.
+- prop table drift는 `npm run components:props-check`로 확인하고, drift가 의도된 변경이면 `npm run components:props`로 갱신합니다. / Check prop table drift with `npm run components:props-check`, and update intentional drift with `npm run components:props`.
 
 ## 구현 규칙 / Implementation Rules
 

--- a/docs/review-and-issue-board.md
+++ b/docs/review-and-issue-board.md
@@ -30,7 +30,7 @@ This table preserves candidates and acceptance criteria from the time they were 
 | [#10](https://github.com/BlingLab/frontend-lab/issues/10) | Done | Overlay dismiss와 focus hook 공통화 / Extract overlay dismiss and focus hooks | component | Escape, outside pointer, focus return 로직이 shared hook으로 정리되었습니다. / Escape, outside pointer, and focus return logic are consolidated into shared hooks. |
 | [#12](https://github.com/BlingLab/frontend-lab/issues/12) | Done | DataGrid virtual scroll 범위 결정 / Decide DataGrid virtual scroll scope | component | large dataset 기준과 ARIA 영향을 별도 후속으로 분리했습니다. / Large dataset criteria and ARIA impact were split into a separate follow-up. |
 | [#46](https://github.com/BlingLab/frontend-lab/issues/46) | P2 | DataGrid virtual scroll ARIA 검증 프로토타입 / Prototype virtual scroll with ARIA validation | component | large dataset, keyboard navigation, selection, screen reader row count/index 전략을 함께 검증합니다. / Validates large dataset behavior, keyboard navigation, selection, and screen reader row count/index strategy together. |
-| [#47](https://github.com/BlingLab/frontend-lab/issues/47) | P2 | 컴포넌트 문서 재생성 전 수동 변경 감지 / Detect manual changes before regenerating component docs | documentation | docs regeneration dry-run, manual protected section, drift 검증 기준을 추가합니다. / Adds docs regeneration dry-run, manual protected sections, and drift validation criteria. |
+| [#47](https://github.com/BlingLab/frontend-lab/issues/47) | Done | 컴포넌트 문서 재생성 전 수동 변경 감지 / Detect manual changes before regenerating component docs | documentation | scaffold dry-run, manual marker, prop table drift check를 추가했습니다. / Added scaffold dry-run, manual markers, and prop table drift checks. |
 | [#48](https://github.com/BlingLab/frontend-lab/issues/48) | P2 | pixel baseline comparison 도입 / Add pixel baseline comparison | quality | screenshot artifact 검증을 baseline comparison까지 확장합니다. / Extends screenshot artifact checks to baseline comparison. |
 | [#49](https://github.com/BlingLab/frontend-lab/issues/49) | Done | 실제 npm publish scope와 권한 확정 / Finalize npm publish scope and permissions | release | package scope를 `@bling-lab/ui`로 확정하고 `private=false`, npm public `publishConfig`, publish 검증을 추가했습니다. / Finalized package scope as `@bling-lab/ui` and added `private=false`, npm public `publishConfig`, and publish verification. |
 
@@ -108,6 +108,7 @@ This table preserves candidates and acceptance criteria from the time they were 
 
 ### 7. 문서 자동화 후속 / Documentation Automation Follow-up
 
+- 상태 / Status: 완료. scaffold dry-run, manual marker, prop table drift check를 추가했습니다. / Done. Added scaffold dry-run, manual markers, and prop table drift checks.
 - 범위 / Scope: component docs regeneration dry-run, manual section protection, generated prop table drift check.
 - 리뷰 포인트 / Review points: 수동 작성 문서 보존, scaffold 범위 명확성, 대량 문서 diff 최소화. / Manual document preservation, clear scaffold scope, and reduced large documentation diffs.
 - 연결 이슈 / Linked issue: [#47](https://github.com/BlingLab/frontend-lab/issues/47)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "components:scaffold": "tsx scripts/scaffold-component-docs.mjs",
     "components:props": "tsx scripts/sync-component-prop-tables.mjs",
-    "components:validate": "tsx scripts/validate-component-system.mjs",
+    "components:props-check": "tsx scripts/sync-component-prop-tables.mjs --check",
+    "components:validate": "tsx scripts/validate-component-system.mjs && npm run components:props-check",
     "build": "npm --workspace @bling-lab/ui run build",
     "dev": "npm --workspace @workspace/docs run dev",
     "docs:dev": "npm --workspace @workspace/docs run dev",

--- a/packages/ui/src/components/README.md
+++ b/packages/ui/src/components/README.md
@@ -60,8 +60,11 @@ npm run components:validate
 문서만 수정했더라도 public export, 폴더 구조, 토큰 계약이 함께 깨지지 않았는지 확인합니다.
 Even documentation-only changes should confirm that public exports, folder structure, and token contracts still hold.
 
-기존 수동 문서를 덮어쓰지 않기 위해 scaffold는 README/spec를 기본적으로 보존합니다. 문서를 재생성해야 할 때만 변경분을 먼저 확인하고 `npm run components:scaffold -- --force-docs`를 실행합니다.
-The scaffold preserves existing README/spec files by default. Regenerate docs only after checking local changes, then run `npm run components:scaffold -- --force-docs`.
+기존 수동 문서를 덮어쓰지 않기 위해 scaffold는 README/spec를 기본적으로 보존합니다. 문서를 재생성해야 할 때는 `npm run components:scaffold -- --force-docs --dry-run`으로 변경분을 먼저 확인하고 `npm run components:scaffold -- --force-docs`를 실행합니다.
+The scaffold preserves existing README/spec files by default. Regenerate docs only after checking local changes with `npm run components:scaffold -- --force-docs --dry-run`, then run `npm run components:scaffold -- --force-docs`.
+
+수동으로 보존해야 하는 내용은 `<!-- ds-manual-start -->`와 `<!-- ds-manual-end -->` 사이에 둡니다. scaffold는 강제 재생성 중에도 이 marker 구간을 유지합니다.
+Put manually preserved content between `<!-- ds-manual-start -->` and `<!-- ds-manual-end -->`. The scaffold keeps this marker block during forced regeneration.
 
 prop table만 갱신할 때는 기존 문서 본문을 유지하는 `npm run components:props`를 사용합니다.
 Use `npm run components:props` to update only prop tables while preserving existing document prose.

--- a/scripts/scaffold-component-docs.mjs
+++ b/scripts/scaffold-component-docs.mjs
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +8,9 @@ import { renderComponentPropTable } from "../packages/ui/src/components/prop-doc
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const force = process.argv.includes("--force");
 const forceDocs = process.argv.includes("--force-docs");
+const dryRun = process.argv.includes("--dry-run");
+const manualStartMarker = "<!-- ds-manual-start -->";
+const manualEndMarker = "<!-- ds-manual-end -->";
 const categoryLabels = new Map(componentCategories.map((category) => [category.id, category.label]));
 const categoryKoreanLabels = new Map([
   ["actions", "액션"],
@@ -263,19 +266,50 @@ export function ${component.name}({ children, ...props }: ${component.name}Props
 `;
 }
 
-async function writeIfMissing(path, content, options = {}) {
+function getManualBlock(content) {
+  const startIndex = content.indexOf(manualStartMarker);
+  const endIndex = content.indexOf(manualEndMarker);
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) return undefined;
+  return content.slice(startIndex, endIndex + manualEndMarker.length);
+}
+
+function preserveManualBlock(currentContent, nextContent) {
+  const currentBlock = getManualBlock(currentContent);
+  if (!currentBlock) return nextContent;
+
+  const nextBlock = getManualBlock(nextContent);
+  if (nextBlock) return nextContent.replace(nextBlock, currentBlock);
+  return `${nextContent.trimEnd()}\n\n## 수동 보호 구간 / Manual Protected Section\n\n${currentBlock}\n`;
+}
+
+async function planWrite(path, content, options = {}) {
   await mkdir(dirname(path), { recursive: true });
 
   const canOverwrite = options.doc ? forceDocs : force;
-  if (existsSync(path) && !canOverwrite) {
-    return false;
+  if (!existsSync(path)) {
+    return { shouldWrite: true, content, reason: "missing" };
   }
 
-  await writeFile(path, content, "utf8");
-  return true;
+  const currentContent = await readFile(path, "utf8");
+  if (!canOverwrite) {
+    return { shouldWrite: false, content: currentContent, reason: "exists" };
+  }
+
+  const nextContent = options.doc ? preserveManualBlock(currentContent, content) : content;
+  if (nextContent === currentContent) {
+    return { shouldWrite: false, content: currentContent, reason: "unchanged" };
+  }
+
+  const manualBlock = getManualBlock(currentContent);
+  return {
+    shouldWrite: true,
+    content: nextContent,
+    reason: manualBlock ? "content differs, manual block preserved" : "content differs"
+  };
 }
 
 let written = 0;
+const plannedWrites = [];
 
 for (const component of componentCatalog) {
   const componentDir = join(
@@ -288,20 +322,42 @@ for (const component of componentCatalog) {
     component.slug
   );
 
-  if (await writeIfMissing(join(componentDir, "README.md"), renderReadme(component), { doc: true })) {
+  const readmePlan = await planWrite(join(componentDir, "README.md"), renderReadme(component), { doc: true });
+  if (readmePlan.shouldWrite) {
+    plannedWrites.push({ path: join(componentDir, "README.md"), reason: readmePlan.reason, content: readmePlan.content });
     written += 1;
   }
 
-  if (await writeIfMissing(join(componentDir, "spec.md"), renderSpec(component), { doc: true })) {
+  const specPlan = await planWrite(join(componentDir, "spec.md"), renderSpec(component), { doc: true });
+  if (specPlan.shouldWrite) {
+    plannedWrites.push({ path: join(componentDir, "spec.md"), reason: specPlan.reason, content: specPlan.content });
     written += 1;
   }
 
-  if (await writeIfMissing(join(componentDir, "index.ts"), renderEntry(component))) {
+  const entryPlan = await planWrite(join(componentDir, "index.ts"), renderEntry(component));
+  if (entryPlan.shouldWrite) {
+    plannedWrites.push({ path: join(componentDir, "index.ts"), reason: entryPlan.reason, content: entryPlan.content });
     written += 1;
   }
-  if (await writeIfMissing(join(componentDir, `${component.slug}.tsx`), renderComponentStub(component))) {
+  const componentPlan = await planWrite(join(componentDir, `${component.slug}.tsx`), renderComponentStub(component));
+  if (componentPlan.shouldWrite) {
+    plannedWrites.push({ path: join(componentDir, `${component.slug}.tsx`), reason: componentPlan.reason, content: componentPlan.content });
     written += 1;
   }
 }
 
-console.log(`${written}개 컴포넌트 파일을 작성했습니다. / ${written} component file(s) written.`);
+if (dryRun) {
+  if (plannedWrites.length === 0) {
+    console.log("변경될 컴포넌트 파일이 없습니다. / No component files would change.");
+  } else {
+    console.log("변경 예정 컴포넌트 파일 / Component files that would change:");
+    for (const plannedWrite of plannedWrites) {
+      console.log(`- ${plannedWrite.path}: ${plannedWrite.reason}`);
+    }
+  }
+} else {
+  for (const plannedWrite of plannedWrites) {
+    await writeFile(plannedWrite.path, plannedWrite.content, "utf8");
+  }
+  console.log(`${written}개 컴포넌트 파일을 작성했습니다. / ${written} component file(s) written.`);
+}

--- a/scripts/sync-component-prop-tables.mjs
+++ b/scripts/sync-component-prop-tables.mjs
@@ -5,6 +5,7 @@ import { componentCatalog } from "../packages/ui/src/components/catalog.ts";
 import { renderComponentPropTable } from "../packages/ui/src/components/prop-docs.ts";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const checkOnly = process.argv.includes("--check") || process.argv.includes("--dry-run");
 
 function renderBlock(component) {
   return `## Prop 표 / Prop Table\n\n${renderComponentPropTable(component)}\n`;
@@ -31,6 +32,7 @@ function upsertPropTable(content, component) {
 }
 
 let written = 0;
+const changedFiles = [];
 
 for (const component of componentCatalog.filter((item) => item.status === "ready")) {
   const componentDir = join(rootDir, "packages", "ui", "src", "components", component.category, component.slug);
@@ -40,10 +42,25 @@ for (const component of componentCatalog.filter((item) => item.status === "ready
     const currentContent = await readFile(filePath, "utf8");
     const nextContent = `${upsertPropTable(currentContent, component).trimEnd()}\n`;
     if (nextContent !== currentContent) {
-      await writeFile(filePath, nextContent, "utf8");
+      changedFiles.push(filePath);
+      if (!checkOnly) {
+        await writeFile(filePath, nextContent, "utf8");
+      }
       written += 1;
     }
   }
 }
 
-console.log(`${written}개 component prop table 문서를 동기화했습니다. / Synced ${written} component prop table document(s).`);
+if (checkOnly && changedFiles.length > 0) {
+  console.error("component prop table drift가 있습니다. / Component prop table drift detected:");
+  for (const changedFile of changedFiles) {
+    console.error(`- ${changedFile}`);
+  }
+  process.exit(1);
+}
+
+if (checkOnly) {
+  console.log("component prop table drift가 없습니다. / No component prop table drift detected.");
+} else {
+  console.log(`${written}개 component prop table 문서를 동기화했습니다. / Synced ${written} component prop table document(s).`);
+}


### PR DESCRIPTION
## 요약 / Summary

- `components:scaffold`에 `--dry-run` 계획 출력을 추가해 재생성 전 변경 파일과 이유를 확인할 수 있게 했습니다. / Adds `--dry-run` planning output to `components:scaffold` so changed files and reasons can be reviewed before regeneration.
- README/spec 수동 보호 marker를 정의하고 `--force-docs` 실행 중 해당 구간을 보존합니다. / Defines README/spec manual protection markers and preserves that block during `--force-docs`.
- `components:props-check`를 추가하고 `components:validate`에 prop table drift 검증을 연결했습니다. / Adds `components:props-check` and wires prop table drift validation into `components:validate`.
- 관련 authoring 문서와 이슈 보드 상태를 갱신했습니다. / Updates the related authoring docs and issue board status.

Closes #47

## 검증 / Verification

- `npm run components:scaffold -- --force-docs --dry-run`
- `npm run components:props-check`
- `npm run components:validate`
- `npm run lint`
- `npm run docs:links`