### PR TITLE
chore: align consumer fixture copy

### DIFF
--- a/apps/consumer-fixture/src/main.tsx
+++ b/apps/consumer-fixture/src/main.tsx
@@ -7,8 +7,8 @@ import { Button as ButtonEntry } from "@bling-lab/ui/components/actions/button";
 import { DataGrid as DataGridEntry } from "@bling-lab/ui/components/data-display/data-grid";
 
 const rows = [
-  { id: "ready", name: "Root export", status: "통과 / Pass" },
-  { id: "entry", name: "Per-component export", status: "통과 / Pass" }
+  { id: "ready", name: "루트 export / Root export", status: "통과 / Pass" },
+  { id: "entry", name: "개별 component export / Per-component export", status: "통과 / Pass" }
 ];
 
 function ConsumerFixture() {

--- a/apps/consumer-fixture/src/main.tsx
+++ b/apps/consumer-fixture/src/main.tsx
@@ -19,17 +19,17 @@ function ConsumerFixture() {
           eyebrow="외부 소비자 / External consumer"
           title="패키지 import 검증 / Package import verification"
           description={`catalog ${componentCatalog.length}개 항목을 root export에서 읽었습니다. / Read ${componentCatalog.length} catalog items from the root export.`}
-          actions={[{ label: "Root action", variant: "outline", tone: "neutral" }]}
+          actions={[{ label: "루트 action / Root action", variant: "outline", tone: "neutral" }]}
         >
           <Stack gap="sm">
             <TextField label="토큰 적용 / Token applied" defaultValue="data-ds-theme=dark" width="full" />
-            <Button>Root Button</Button>
-            <ButtonEntry variant="outline" tone="neutral">Entry Button</ButtonEntry>
-            <Badge label="styles.css imported" tone="success" />
+            <Button>루트 Button / Root Button</Button>
+            <ButtonEntry variant="outline" tone="neutral">개별 entry Button / Entry Button</ButtonEntry>
+            <Badge label="styles.css import됨 / styles.css imported" tone="success" />
           </Stack>
         </Card>
         <DataGrid
-          caption="Root DataGrid"
+          caption="루트 DataGrid / Root DataGrid"
           columns={[
             { key: "name", label: "이름 / Name" },
             { key: "status", label: "상태 / Status" }
@@ -38,7 +38,7 @@ function ConsumerFixture() {
           rowKey={(row) => row.id}
         />
         <DataGridEntry
-          caption="Entry DataGrid"
+          caption="개별 entry DataGrid / Entry DataGrid"
           columns={[
             { key: "name", label: "이름 / Name" },
             { key: "status", label: "상태 / Status" }

--- a/apps/docs/src/main.tsx
+++ b/apps/docs/src/main.tsx
@@ -415,8 +415,7 @@ function App() {
             <p className="eyebrow">React 컴포넌트 카탈로그 / React component catalog</p>
             <h1 id="page-title">프로젝트에 바로 가져다 쓰는 React 컴포넌트 시스템 / React Component System Ready For Product Work</h1>
             <p className="intro-copy">
-              이 문서 앱은 `@bling-lab/ui`의 실제 React 컴포넌트를 import해 렌더링합니다.
-              This docs app renders real React components imported from `@bling-lab/ui`.
+              이 문서 앱은 `@bling-lab/ui`의 실제 React 컴포넌트를 import해 렌더링합니다. / This docs app renders real React components imported from `@bling-lab/ui`.
             </p>
             <div className="intro-actions" aria-label="주요 이동 / Primary links">
               <a className="intro-link primary" href="#components">컴포넌트 보기 / View components</a>

--- a/docs/component-authoring.md
+++ b/docs/component-authoring.md
@@ -60,15 +60,13 @@ Every component documents the items below before implementation.
 
 ## export 규칙 / Export Rules
 
-루트 export는 `packages/ui/src/index.ts`에서만 관리합니다.
-Root exports are managed only in `packages/ui/src/index.ts`.
+루트 export는 `packages/ui/src/index.ts`에서만 관리합니다. / Root exports are managed only in `packages/ui/src/index.ts`.
 
 ```ts
 export { Button, type ButtonProps } from "./components/actions/button";
 ```
 
-컴포넌트 폴더의 `index.ts`는 자기 구현만 다시 export합니다.
-Each component folder's `index.ts` re-exports only its own implementation.
+컴포넌트 폴더의 `index.ts`는 자기 구현만 다시 export합니다. / Each component folder's `index.ts` re-exports only its own implementation.
 
 ```ts
 export { Button, type ButtonProps } from "./button";

--- a/docs/datagrid-virtual-scroll.md
+++ b/docs/datagrid-virtual-scroll.md
@@ -1,7 +1,6 @@
 # DataGrid 가상 스크롤 결정 / DataGrid Virtual Scroll Decision
 
-DataGrid의 virtual scroll은 현재 `@bling-lab/ui` v0.1 범위에 포함하지 않습니다.
-DataGrid virtual scroll is not included in the current `@bling-lab/ui` v0.1 scope.
+DataGrid의 virtual scroll은 현재 `@bling-lab/ui` v0.1 범위에 포함하지 않습니다. / DataGrid virtual scroll is not included in the current `@bling-lab/ui` v0.1 scope.
 
 ## 결정 / Decision
 
@@ -12,8 +11,7 @@ DataGrid virtual scroll is not included in the current `@bling-lab/ui` v0.1 scop
 
 ## 성능 목표 / Performance Goals
 
-virtualization을 도입하려면 아래 목표를 먼저 충족해야 합니다.
-Virtualization must meet the goals below before adoption.
+virtualization을 도입하려면 아래 목표를 먼저 충족해야 합니다. / Virtualization must meet the goals below before adoption.
 
 - 초기 render는 1,000 row dataset 기준 200ms 이하를 목표로 합니다. / Initial render should target 200ms or less for a 1,000-row dataset.
 - scroll 중 main thread 긴 task는 50ms를 넘지 않도록 설계합니다. / Long main-thread tasks during scroll should stay below 50ms.
@@ -22,8 +20,7 @@ Virtualization must meet the goals below before adoption.
 
 ## 프로토타입 검증 / Prototype Validation
 
-가상 스크롤은 아직 public API가 아니지만, ARIA 전략과 성능 smoke는 `npm run test:datagrid-virtual`로 검증합니다.
-Virtual scroll is not a public API yet, but ARIA strategy and performance smoke are validated with `npm run test:datagrid-virtual`.
+가상 스크롤은 아직 public API가 아니지만, ARIA 전략과 성능 smoke는 `npm run test:datagrid-virtual`로 검증합니다. / Virtual scroll is not a public API yet, but ARIA strategy and performance smoke are validated with `npm run test:datagrid-virtual`.
 
 - current baseline은 500 row DataGrid가 `aria-rowcount`, selection column 포함 `aria-colcount`, row keyboard state를 유지하는지 확인합니다. / The current baseline checks that a 500-row DataGrid keeps `aria-rowcount`, `aria-colcount` including the selection column, and row keyboard state.
 - prototype fixture는 1,000 row 중 visible window 40 row만 렌더링하고 `aria-rowcount`, absolute `aria-rowindex`, `aria-activedescendant`를 검증합니다. / The prototype fixture renders only a 40-row visible window from 1,000 rows and verifies `aria-rowcount`, absolute `aria-rowindex`, and `aria-activedescendant`.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -63,8 +63,7 @@ Verify `packages/ui/package.json` export paths against real output with `npm run
 
 ## 배포 전 판단 / Pre-Release Decision
 
-이 레포는 현재 workspace 기반 베이스입니다. 실제 npm 또는 GitHub Packages 배포는 [릴리즈 정책](./release-policy.md)을 기준으로 별도 위험 변경 PR에서 결정합니다.
-This repo is currently a workspace-based foundation. Publishing to npm or GitHub Packages should be decided in a separate risky-change PR using [Release Policy](./release-policy.md).
+이 레포는 현재 workspace 기반 베이스입니다. 실제 npm 또는 GitHub Packages 배포는 [릴리즈 정책](./release-policy.md)을 기준으로 별도 위험 변경 PR에서 결정합니다. / This repo is currently a workspace-based foundation. Publishing to npm or GitHub Packages should be decided in a separate risky-change PR using [Release Policy](./release-policy.md).
 
 ## 실제 publish 전 확인 / Before Real Publish
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -79,8 +79,7 @@ export function Example() {
 }
 ```
 
-개별 컴포넌트도 폴더 단위로 import할 수 있습니다.
-Individual components can also be imported by folder.
+개별 컴포넌트도 폴더 단위로 import할 수 있습니다. / Individual components can also be imported by folder.
 
 ```tsx
 import { Button } from "@bling-lab/ui/components/actions/button";

--- a/packages/ui/src/components/actions/button/button.tsx
+++ b/packages/ui/src/components/actions/button/button.tsx
@@ -55,7 +55,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     >
       {loading ? <span className="ds-Spinner" aria-hidden="true" /> : null}
       {iconStart ? <span className="ds-Icon" aria-hidden="true">{iconStart}</span> : null}
-      {children ?? label ?? "Button"}
+      {children ?? label ?? "버튼 / Button"}
       {iconEnd ? <span className="ds-Icon" aria-hidden="true">{iconEnd}</span> : null}
     </button>
   );

--- a/packages/ui/src/components/feedback/badge/badge.tsx
+++ b/packages/ui/src/components/feedback/badge/badge.tsx
@@ -31,7 +31,7 @@ export function Badge({
   return (
     <span className={classNames("ds-Badge", className)} data-tone={tone} data-variant={variant} data-size={size} {...props}>
       {iconStart ? <span className="ds-Badge-icon" aria-hidden="true">{iconStart}</span> : null}
-      {children ?? label ?? "Badge"}
+      {children ?? label ?? "배지 / Badge"}
       {iconEnd ? <span className="ds-Badge-icon" aria-hidden="true">{iconEnd}</span> : null}
       {removable ? (
         <button className="ds-Badge-remove" type="button" aria-label={removeLabel} onClick={onRemove}>

--- a/packages/ui/src/components/forms/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/forms/checkbox/checkbox.tsx
@@ -9,7 +9,7 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
 }
 
 export function Checkbox({
-  label = "Checkbox",
+  label = "체크박스 / Checkbox",
   description,
   indeterminate = false,
   disabled,

--- a/packages/ui/src/components/forms/radio-group/radio-group.tsx
+++ b/packages/ui/src/components/forms/radio-group/radio-group.tsx
@@ -21,7 +21,7 @@ export interface RadioGroupProps extends Omit<HTMLAttributes<HTMLFieldSetElement
 }
 
 export function RadioGroup({
-  label = "Radio group",
+  label = "라디오 그룹 / Radio group",
   description,
   value,
   defaultValue,

--- a/packages/ui/src/components/forms/switch/switch.tsx
+++ b/packages/ui/src/components/forms/switch/switch.tsx
@@ -10,7 +10,7 @@ export interface SwitchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement
 }
 
 export function Switch({
-  label = "Switch",
+  label = "스위치 / Switch",
   checked,
   defaultChecked = false,
   disabled,

--- a/packages/ui/src/components/overlays/dialog/dialog.tsx
+++ b/packages/ui/src/components/overlays/dialog/dialog.tsx
@@ -97,11 +97,11 @@ export function Dialog({
         }}
       >
         <div className="ds-Dialog-header">
-          <h3 className="ds-Dialog-title" id={titleId}>{title ?? "Dialog"}</h3>
+          <h3 className="ds-Dialog-title" id={titleId}>{title ?? "대화상자 / Dialog"}</h3>
           <IconButton label={closeLabel} icon={<Icon name="x" />} onClick={close} />
         </div>
         {description ? <p className="ds-Dialog-description" id={descriptionId}>{description}</p> : null}
-        <div className="ds-Dialog-body">{children ?? "Dialog content"}</div>
+        <div className="ds-Dialog-body">{children ?? "대화상자 내용 / Dialog content"}</div>
         <div className="ds-Dialog-actions">
           {actions.map(renderAction)}
           <Button variant="outline" tone="neutral" onClick={close}>{closeLabel}</Button>

--- a/packages/ui/src/components/overlays/popover/popover.tsx
+++ b/packages/ui/src/components/overlays/popover/popover.tsx
@@ -52,7 +52,7 @@ export function Popover({ triggerLabel = "열기 / Open", title, children, open,
       </Button>
       <div className="ds-Popover-panel" id={panelId} data-placement={placement} data-state={currentOpen ? "open" : "closed"} hidden={!currentOpen}>
         {title ? <strong className="ds-Popover-title">{title}</strong> : null}
-        <div className="ds-Popover-content">{children ?? "Popover content"}</div>
+        <div className="ds-Popover-content">{children ?? "팝오버 내용 / Popover content"}</div>
       </div>
     </div>
   );

--- a/packages/ui/src/components/overlays/tooltip/tooltip.tsx
+++ b/packages/ui/src/components/overlays/tooltip/tooltip.tsx
@@ -11,7 +11,7 @@ export interface TooltipProps extends Omit<HTMLAttributes<HTMLSpanElement>, "con
   trigger?: ReactNode;
 }
 
-export function Tooltip({ label = "?", content = "Tooltip", placement = "top", delay = 300, disabled = false, trigger, className, ...props }: TooltipProps) {
+export function Tooltip({ label = "?", content = "툴팁 설명 / Tooltip", placement = "top", delay = 300, disabled = false, trigger, className, ...props }: TooltipProps) {
   const [open, setOpen] = useState(false);
   const tooltipId = useId();
   const openTimer = useRef<number | undefined>(undefined);

--- a/scripts/copy-ui-assets.mjs
+++ b/scripts/copy-ui-assets.mjs
@@ -12,4 +12,4 @@ const tokensCss = await readFile(tokensSource, "utf8");
 const uiCss = await readFile(source, "utf8");
 await writeFile(target, `${tokensCss.trimEnd()}\n\n${uiCss.trimEnd()}\n`, "utf8");
 
-console.log("UI CSS asset copied with tokens. / UI CSS asset copied with tokens.");
+console.log("UI CSS asset을 token과 함께 복사했습니다. / UI CSS asset copied with tokens.");


### PR DESCRIPTION
## 요약 / Summary
- 소비자 fixture의 영문-only UI 문구를 한글 우선 병기로 맞췄습니다. / Aligned English-only consumer fixture UI copy to Korean-first bilingual text.
- UI CSS asset 복사 스크립트의 개발자 출력 메시지를 한글 우선 병기로 고쳤습니다. / Updated the UI CSS asset copy script output to Korean-first bilingual text.
- 문서 앱 intro와 짧은 문서 문장을 한글 우선 병기 형식으로 정리했습니다. / Aligned the docs app intro and short documentation sentences to Korean-first bilingual format.
- 공유 컴포넌트 fallback 문구를 한글 우선 병기 기본값으로 정리했습니다. / Updated shared component fallback copy to Korean-first bilingual defaults.

## 검증 / Verification
- npm run components:validate
- npm run typecheck
- npm run test:interaction
- npm run lint
- npm run docs:links
- npm --workspace @workspace/docs run build
- npm run test