### PR TITLE
[codex] 컴포넌트 분류 catalog 동기화 / Sync component taxonomy catalog

### DIFF
--- a/docs/component-taxonomy.md
+++ b/docs/component-taxonomy.md
@@ -20,6 +20,7 @@ Components that execute explicit user commands.
 
 - Button
 - IconButton
+- Icon
 
 ## 폼 / Forms
 
@@ -30,9 +31,12 @@ Components where users enter or select values.
 - TextField
 - Textarea
 - Select
+- DatePicker
+- Combobox
 - Checkbox
 - RadioGroup
 - Switch
+- FileUploader
 
 ## 피드백 / Feedback
 
@@ -54,6 +58,7 @@ Components that create a temporary UI layer above the current screen.
 - Popover
 - Tooltip
 - DropdownMenu
+- CommandPalette
 
 ## 내비게이션 / Navigation
 
@@ -63,12 +68,20 @@ Handles movement across locations or panel switching in the same context.
 - Tabs
 - Breadcrumb
 - Pagination
+- Stepper
+- NavigationRail
+- SideNav
 
 ## 레이아웃 / Layout
 
 콘텐츠 surface와 구획을 만드는 구조 컴포넌트입니다.
 Structural components that create content surfaces and sections.
 
+- Container
+- Row
+- Col
+- Stack
+- Inline
 - Card
 - Divider
 
@@ -78,8 +91,24 @@ Structural components that create content surfaces and sections.
 Components that present information in structured form.
 
 - Table
+- DataGrid
 - EmptyState
 - List
+
+## 현재 카탈로그 / Current Catalog
+
+현재 public catalog는 40개 ready 컴포넌트로 구성됩니다.
+The current public catalog contains 40 ready components.
+
+| 분류 / Category | 컴포넌트 / Components | 기준 / Rule |
+| --- | --- | --- |
+| Actions | Button, IconButton, Icon | 명령 실행과 명령 UI에 필요한 시각 primitive입니다. / Command execution and visual primitives needed for command UI. |
+| Forms | Field, TextField, Textarea, Select, DatePicker, Combobox, Checkbox, RadioGroup, Switch, FileUploader | 값 입력, 값 선택, 검증 관계를 담당합니다. / Handles value entry, value selection, and validation relationships. |
+| Feedback | Alert, Toast, Badge, Progress, Skeleton | 상태, 결과, 진행, 로딩 placeholder를 전달합니다. / Communicates status, outcomes, progress, and loading placeholders. |
+| Overlays | Dialog, Popover, Tooltip, DropdownMenu, CommandPalette | 현재 surface 위에 임시 계층을 만들고 focus/dismiss 계약을 가집니다. / Creates temporary layers above the current surface with focus and dismiss contracts. |
+| Navigation | Tabs, Breadcrumb, Pagination, Stepper, NavigationRail, SideNav | 위치 이동, 단계 진행, 같은 맥락의 panel 전환을 담당합니다. / Handles navigation, step progress, and related panel switching. |
+| Layout | Container, Row, Col, Stack, Inline, Card, Divider | page width, grid, spacing, surface, 구획을 담당합니다. / Handles page width, grid, spacing, surfaces, and section separation. |
+| Data Display | Table, DataGrid, EmptyState, List | 레코드, 컬렉션, 빈 상태, tabular data를 구조화합니다. / Structures records, collections, empty states, and tabular data. |
 
 ## 성숙도 / Maturity
 


### PR DESCRIPTION
## 변경 사항 / Changes

- `docs/component-taxonomy.md`에 실제 public catalog 기준 누락 컴포넌트를 반영했습니다. / Updated `docs/component-taxonomy.md` with components missing from the actual public catalog.
- 현재 catalog가 40개 ready 컴포넌트로 구성된다는 요약 표를 추가했습니다. / Added a summary table stating that the current catalog contains 40 ready components.
- #56의 P1 후보 중 확정 가능한 항목을 #58-#66으로 분리하고, 보류 후보 판단을 #56 코멘트에 남겼습니다. / Split confirmed P1 candidates from #56 into #58-#66 and left deferred-candidate decisions in a #56 comment.

## 검증 / Validation

- `node` catalog 대조 스크립트: 40개 catalog 항목이 taxonomy 문서에 모두 반영됨 / `node` catalog comparison script: all 40 catalog entries are represented in the taxonomy document.
- `npm run docs:links` / `npm run docs:links`

Closes #56